### PR TITLE
Fix typo in handling of no_rewrite_prefixes

### DIFF
--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -156,7 +156,7 @@ _WBWombat = (function() {
         }
 
         // OPTS: additional ignore prefixes
-        if (wb_opts.norewrite_prefixes) {
+        if (wb_opts.no_rewrite_prefixes) {
             if (starts_with(url, wb_opts.no_rewrite_prefixes)) {
                 return url;
             }


### PR DESCRIPTION
I think this must be a typo.