### PR TITLE
Use webencodings to encode head_insert_str.

### DIFF
--- a/pywb/rewrite/rewrite_content.py
+++ b/pywb/rewrite/rewrite_content.py
@@ -1,5 +1,6 @@
 #import chardet
 import pkgutil
+import webencodings
 import yaml
 import re
 
@@ -164,7 +165,7 @@ class RewriteContent:
 
                 if charset:
                     try:
-                        head_insert_str = head_insert_orig.encode(charset)
+                        head_insert_str = webencodings.encode(head_insert_orig, charset)
                     except:
                         pass
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,8 @@ setup(
         'jinja2',
         'surt',
         'pyyaml',
-        'watchdog'
+        'watchdog',
+        'webencodings',
        ],
     tests_require=[
         'pytest',


### PR DESCRIPTION
Here's a basic implementation of using python-webencodings to handle character encoding.

This correctly causes the head insert to be added to http://www.geocities.jp/koreanlaws/yousiengumi.html using shift_jis encoding instead of falling back on utf-8. (I confirmed this via print statements.)

I've thought of two cases where this might actually matter:

- If the collection name or some other part of wbinfo has unicode characters. (Probably a good idea in general to support foreign-language collection names, right?)
- If the page is in some non-utf8-compatible encoding (utf16? others?) set via response headers.

... but I confess I haven't actually tested either of those.