### PR TITLE
Fix test_rewrite_live.test_example_1

### DIFF
--- a/pywb/rewrite/test/test_rewrite_live.py
+++ b/pywb/rewrite/test/test_rewrite_live.py
@@ -1,3 +1,5 @@
+import requests
+
 from pywb.rewrite.rewrite_live import LiveRewriter
 from pywb.rewrite.url_rewriter import UrlRewriter
 from pywb.rewrite.wburl import WbUrl
@@ -200,10 +202,17 @@ def test_local_unclosed_script():
 
 
 def test_example_1():
-    status_headers, buff = get_rewritten('http://example.com/', urlrewriter, req_headers={'Connection': 'close'})
+    TEST_URL = 'http://example.com'
+
+    original_response = requests.get(TEST_URL)
+    status_headers, buff = get_rewritten(TEST_URL, urlrewriter, req_headers={'Connection': 'close'})
+
 
     # verify header rewriting
-    assert (('X-Archive-Orig-Content-Length', '1270') in status_headers.headers), status_headers
+    def header_match(name):
+        return name.lower() == 'x-archive-orig-content-length'
+    content_length = [header[1] for header in status_headers.headers if header_match(header[0])]
+    assert content_length == [original_response.headers['content-length']]
 
 
     # verify utf-8 charset detection


### PR DESCRIPTION
One of the live-rewrite tests fetches 'http://example.com' and had hardcoded assumptions
about the value of the 'Content-Length' header in the response and
the casing of the header.

The expected content length is for the uncompressed content size.
However, the current version of the requests lib sets the
'Accept-Encoding: gzip' header by default and also lowercases
the names of headers in the response.

The proper approach here would be to mock out the HTTP request.

This takes a slightly uglier initial step of performing a direct
request and comparing the X-Archive-Content-Length header
in the proxy's response to that of the original URL.

A related issue is that a `test_loaders` request which also queries example.com
is failing and it looks like it may be for the same reason (compressed vs. non-compressed response)