### PR TITLE
Enable testing against Safari on Sauce Labs and local browsers when SL credentials are not available

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.js]
+indent_style=space
+indent_size=4

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ nosetests.xml
 .pydevproject
 
 .vagrant
+
+# Node
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,11 @@ python:
 
 os:
   - linux
-#  - osx
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - node_modules
 
 sudo: false
 
@@ -16,9 +20,11 @@ install:
   - pip install git+https://github.com/esnme/ultrajson.git
   - python setup.py -q install
   - pip install coverage pytest-cov coveralls --use-mirrors
+  - npm install
 
 script:
-    python setup.py test
+  - python setup.py test
+  - cd karma-tests && make test
 
 after_success:
     coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ sudo: false
 install:
   - "pip install 'argparse>=1.2.1' --allow-all-external"
   - pip install boto certauth
+  - pip install git+https://github.com/esnme/ultrajson.git
   - python setup.py -q install
   - pip install coverage pytest-cov coveralls --use-mirrors
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-PyWb 0.10.10
-============
+PyWb 0.11.0
+===========
 
 .. image:: https://travis-ci.org/ikreymer/pywb.svg?branch=master
       :target: https://travis-ci.org/ikreymer/pywb

--- a/karma-tests/Makefile
+++ b/karma-tests/Makefile
@@ -1,0 +1,4 @@
+NODE_BIN_DIR=../node_modules/.bin
+
+test:
+	$(NODE_BIN_DIR)/karma start --single-run

--- a/karma-tests/karma.conf.js
+++ b/karma-tests/karma.conf.js
@@ -1,0 +1,90 @@
+if (!process.env['SAUCE_USERNAME'] || !process.env['SAUCE_ACCESS_KEY']) {
+    console.error('Sauce Labs account details not set, skipping Karma tests');
+    process.exit(0);
+}
+
+var sauceLabsConfig = {
+    testName: 'PyWB Client Tests',
+};
+
+// see https://github.com/karma-runner/karma-sauce-launcher/issues/73
+if (process.env.TRAVIS_JOB_NUMBER) {
+    sauceLabsConfig.startConnect = false;
+    sauceLabsConfig.tunnelIdentifier = process.env.TRAVIS_JOB_NUMBER;
+}
+
+var WOMBAT_JS_PATH = 'pywb/static/wombat.js';
+
+var customLaunchers = {
+    sl_chrome: {
+        base: 'SauceLabs',
+        browserName: 'chrome',
+    },
+
+    sl_firefox: {
+        base: 'SauceLabs',
+        browserName: 'firefox',
+    },
+
+/*  Safari and Edge are currently broken in
+    pywb.
+
+    See: https://github.com/ikreymer/pywb/issues/148 (Edge)
+         https://github.com/ikreymer/pywb/issues/147 (Safari)
+
+    sl_safari: {
+        base: 'SauceLabs',
+        browserName: 'safari',
+        platform: 'OS X 10.11',
+        version: '9.0',
+    },
+    sl_edge: {
+        base: 'SauceLabs',
+        browserName: 'MicrosoftEdge',
+    },
+*/
+};
+
+module.exports = function(config) {
+  config.set({
+    basePath: '../',
+
+    frameworks: ['mocha', 'chai'],
+
+    files: [
+      {
+        pattern: WOMBAT_JS_PATH,
+        watched: true,
+        included: false,
+        served: true,
+      },
+      'karma-tests/*.spec.js',
+    ],
+
+    preprocessors: {},
+
+    reporters: ['progress'],
+
+    port: 9876,
+
+    colors: true,
+
+    logLevel: config.LOG_INFO,
+
+    autoWatch: true,
+
+    sauceLabs: sauceLabsConfig,
+
+    // use an extended timeout for capturing Sauce Labs
+    // browsers in case the service is busy
+    captureTimeout: 3 * 60000,
+
+    customLaunchers: customLaunchers,
+
+    browsers: Object.keys(customLaunchers),
+
+    singleRun: false,
+
+    concurrency: Infinity
+  })
+};

--- a/karma-tests/karma.conf.js
+++ b/karma-tests/karma.conf.js
@@ -1,8 +1,3 @@
-if (!process.env['SAUCE_USERNAME'] || !process.env['SAUCE_ACCESS_KEY']) {
-    console.error('Sauce Labs account details not set, skipping Karma tests');
-    process.exit(0);
-}
-
 var sauceLabsConfig = {
     testName: 'PyWB Client Tests',
 };
@@ -15,7 +10,7 @@ if (process.env.TRAVIS_JOB_NUMBER) {
 
 var WOMBAT_JS_PATH = 'pywb/static/wombat.js';
 
-var customLaunchers = {
+var sauceLaunchers = {
     sl_chrome: {
         base: 'SauceLabs',
         browserName: 'chrome',
@@ -26,24 +21,44 @@ var customLaunchers = {
         browserName: 'firefox',
     },
 
-/*  Safari and Edge are currently broken in
-    pywb.
-
-    See: https://github.com/ikreymer/pywb/issues/148 (Edge)
-         https://github.com/ikreymer/pywb/issues/147 (Safari)
-
     sl_safari: {
         base: 'SauceLabs',
         browserName: 'safari',
         platform: 'OS X 10.11',
         version: '9.0',
     },
+
+/*  Edge is currently broken in
+    pywb.
+
+    See: https://github.com/ikreymer/pywb/issues/148 (Edge)
+         https://github.com/ikreymer/pywb/issues/147 (Safari)
+
+
     sl_edge: {
         base: 'SauceLabs',
         browserName: 'MicrosoftEdge',
     },
 */
 };
+
+var localLaunchers = {
+    localFirefox: {
+        base: 'Firefox',
+    },
+};
+
+var customLaunchers = {};
+
+if (process.env['SAUCE_USERNAME'] && process.env['SAUCE_ACCESS_KEY']) {
+    customLaunchers = sauceLaunchers;
+} else {
+    console.error('Sauce Labs account details not set, ' +
+                  'Karma tests will be run only against local browsers.' +
+                  'Set SAUCE_USERNAME and SAUCE_ACCESS_KEY environment variables to ' +
+                  'run tests against Sauce Labs browsers');
+    customLaunchers = localLaunchers;
+}
 
 module.exports = function(config) {
   config.set({

--- a/karma-tests/wombat.spec.js
+++ b/karma-tests/wombat.spec.js
@@ -44,8 +44,21 @@ function runWombatTest(testCase, done) {
             };
 
             // expose chai's assertion testing API to the test script
-            assert = window.parent.assert;
-            reportError = window.parent.reportError;
+            window.assert = window.parent.assert;
+            window.reportError = window.parent.reportError;
+
+            // helpers which check whether DOM property overrides are supported
+            // in the current browser
+            window.domTests = {
+                areDOMPropertiesConfigurable: function () {
+                    var descriptor = Object.getOwnPropertyDescriptor(Node.prototype, 'baseURI');
+                    if (descriptor && !descriptor.configurable) {
+                        return false;
+                    } else {
+                        return true;
+                    }
+                }
+            };
         });
 
         try {
@@ -123,7 +136,9 @@ describe('WombatJS', function () {
                 if (typeof baseURI !== 'string') {
                     throw new Error('baseURI is not a string');
                 }
-                assert.equal(baseURI, 'http:///dummy.html');
+                if (domTests.areDOMPropertiesConfigurable()) {
+                    assert.equal(baseURI, 'http:///dummy.html');
+                }
             },
         }, done);
     });
@@ -141,7 +156,9 @@ describe('WombatJS', function () {
             html: '<a href="foobar.html" id="link">A link</a>',
             testScript: function () {
                 var link = document.getElementById('link');
-                assert.equal(link.href, 'http:///foobar.html');
+                if (domTests.areDOMPropertiesConfigurable()) {
+                    assert.equal(link.href, 'http:///foobar.html');
+                }
             },
         }, done);
     });

--- a/karma-tests/wombat.spec.js
+++ b/karma-tests/wombat.spec.js
@@ -1,0 +1,148 @@
+var WOMBAT_SRC = '../pywb/static/wombat.js';
+var DEFAULT_TIMEOUT = 20000;
+
+// creates a new document in an <iframe> and runs
+// a WombatJS test case in it.
+//
+// A new <iframe> is used for each test so that each
+// case is run with fresh Document and Window objects,
+// since Wombat monkey-patches many Document and Window
+// functions
+//
+function runWombatTest(testCase, done) {
+    // create an <iframe>
+    var testFrame = document.createElement('iframe');
+    testFrame.src = '/dummy.html';
+    document.body.appendChild(testFrame);
+
+    testFrame.contentWindow.addEventListener('load', function () {
+        var testDocument = testFrame.contentDocument;
+
+        function runFunctionInIFrame(func) {
+            testFrame.contentWindow.eval('(' + func.toString() + ')()');
+        }
+
+        // expose an error reporting function to the <iframe>
+        window.reportError = function(ex) {
+            done(new Error(ex));
+        };
+
+        // expose chai assertions to the <iframe>
+        window.assert = assert;
+
+        runFunctionInIFrame(function () {
+            // re-assign the iframe's console object to the parent window's
+            // console so that messages are intercepted by Karma
+            // and output to wherever it is configured to send
+            // console logs (typically stdout)
+            console = window.parent.console;
+            window.onerror = function (message, url, line, col, error) {
+                if (error) {
+                    console.log(error.stack);
+                }
+                reportError(new Error(message));
+            };
+
+            // expose chai's assertion testing API to the test script
+            assert = window.parent.assert;
+            reportError = window.parent.reportError;
+        });
+
+        try {
+            runFunctionInIFrame(testCase.initScript);
+        } catch (e) {
+            throw new Error('Configuring Wombat failed: ' + e.toString());
+        }
+
+        try {
+            testFrame.contentWindow.eval(testCase.wombatScript);
+            runFunctionInIFrame(function () {
+                new window._WBWombat(wbinfo);
+            });
+        } catch (e) {
+            throw new Error('Initializing WombatJS failed: ' + e.toString());
+        }
+
+        if (testCase.html) {
+            testDocument.body.innerHTML = testCase.html;
+        }
+
+        if (testCase.testScript) {
+            try {
+                runFunctionInIFrame(testCase.testScript);
+            } catch (e) {
+                throw new Error('Test script failed: ' + e.toString());
+            }
+        }
+
+        testFrame.remove();
+        done();
+    });
+}
+
+describe('WombatJS', function () {
+    this.timeout(DEFAULT_TIMEOUT);
+
+    var wombatScript;
+
+    before(function (done) {
+        // load the source of the WombatJS content
+        // rewriting script
+        var req = new XMLHttpRequest();
+        req.open('GET', '/base/pywb/static/wombat.js');
+        req.onload = function () {
+            wombatScript = req.responseText;
+            done();
+        };
+        req.send();
+    });
+
+    it('should load', function (done) {
+        runWombatTest({
+            initScript: function () {
+                wbinfo = {
+                    wombat_opts: {},
+                };
+            },
+            wombatScript: wombatScript,
+        }, done);
+    });
+
+    it('should rewrite document.baseURI', function (done) {
+        runWombatTest({
+            initScript: function () {
+                wbinfo = {
+                    wombat_opts: {},
+                    prefix: window.location.origin,
+                    wombat_ts: '',
+                };
+            },
+            wombatScript: wombatScript,
+            testScript: function () {
+                var baseURI = document.baseURI;
+                if (typeof baseURI !== 'string') {
+                    throw new Error('baseURI is not a string');
+                }
+                assert.equal(baseURI, 'http:///dummy.html');
+            },
+        }, done);
+    });
+
+    it('should rewrite links in dynamically injected <a> tags', function (done) {
+        runWombatTest({
+            initScript: function () {
+                wbinfo = {
+                    wombat_opts: {},
+                    prefix: window.location.origin,
+                    wombat_ts: '',
+                };
+            },
+            wombatScript: wombatScript,
+            html: '<a href="foobar.html" id="link">A link</a>',
+            testScript: function () {
+                var link = document.getElementById('link');
+                assert.equal(link.href, 'http:///foobar.html');
+            },
+        }, done);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "pywb",
+  "version": "1.0.0",
+  "description": "Web archival replay tools",
+  "main": "index.js",
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ikreymer/pywb.git"
+  },
+  "author": "",
+  "license": "GPL-3.0",
+  "bugs": {
+    "url": "https://github.com/ikreymer/pywb/issues"
+  },
+  "homepage": "https://github.com/ikreymer/pywb#readme",
+  "devDependencies": {
+    "chai": "^3.4.1",
+    "karma": "^0.13.15",
+    "karma-chai": "^0.1.0",
+    "karma-chrome-launcher": "^0.2.1",
+    "karma-firefox-launcher": "^0.1.7",
+    "karma-html2js-preprocessor": "^0.1.0",
+    "karma-mocha": "^0.2.1",
+    "karma-sauce-launcher": "^0.3.0",
+    "mocha": "^2.3.4"
+  }
+}

--- a/pywb/__init__.py
+++ b/pywb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.10.10'
+__version__ = '0.11.0'
 
 DEFAULT_CONFIG = 'pywb/default_config.yaml'
 

--- a/pywb/default_config.yaml
+++ b/pywb/default_config.yaml
@@ -23,6 +23,7 @@ paths:
         proxy_cert_download_html: proxy_cert_download.html
         proxy_select_html: proxy_select.html
 
+        info_json: collinfo.json
 
 templates_dirs:
     - templates
@@ -49,6 +50,7 @@ not_found_html: not_found.html
 proxy_cert_download_html: proxy_cert_download.html
 proxy_select_html: proxy_select.html
 
+info_json: collinfo.json
 
 static_default_prefix: &static_default_prefix static/__pywb
 static_shared_prefix: static/__shared

--- a/pywb/framework/archivalrouter.py
+++ b/pywb/framework/archivalrouter.py
@@ -23,9 +23,12 @@ class ArchivalRouter(object):
 
         self.home_view = kwargs.get('home_view')
         self.error_view = kwargs.get('error_view')
+        self.info_view = kwargs.get('info_view')
 
-        self.urlrewriter_class = (kwargs.get('config', {}).
-                                  get('urlrewriter_class', UrlRewriter))
+        config = kwargs.get('config', {})
+        self.urlrewriter_class = config.get('urlrewriter_class', UrlRewriter)
+
+        self.enable_coll_info = config.get('enable_coll_info', False)
 
     def __call__(self, env):
         request_uri = self.ensure_rel_uri_set(env)
@@ -42,6 +45,13 @@ class ArchivalRouter(object):
         # Default Home Page
         if request_uri in ['/', '/index.html', '/index.htm']:
             return self.render_home_page(env)
+
+        if self.enable_coll_info and request_uri in ['/collinfo.json']:
+            params = env.get('pywb.template_params', {})
+            host = WbRequest.make_host_prefix(env)
+            return self.info_view.render_response(env=env, host=host, routes=self.routes,
+                                                  content_type='application/json',
+                                                  **params)
 
         return self.fallback(env, self) if self.fallback else None
 

--- a/pywb/framework/cache.py
+++ b/pywb/framework/cache.py
@@ -5,6 +5,9 @@ except ImportError:
     uwsgi_cache = False
 
 
+from redis import StrictRedis
+
+
 #=================================================================
 class UwsgiCache(object):  # pragma: no cover
     def __setitem__(self, item, value):
@@ -27,7 +30,31 @@ class DefaultCache(dict):
 
 
 #=================================================================
-def create_cache():
+class RedisCache(object):
+    def __init__(self, redis_url):
+        # must be of the form redis://host:port/db/key
+        redis_url, key = redis_url.rsplit('/', 1)
+        self.redis = StrictRedis.from_url(redis_url)
+        self.key = key
+
+    def __setitem__(self, item, value):
+        self.redis.hset(self.key, item, value)
+
+    def __getitem__(self, item):
+        return self.redis.hget(self.key, item)
+
+    def __contains__(self, item):
+        return self.redis.hexists(self.key, item)
+
+    def __delitem__(self, item):
+        self.redis.hdel(self.key, item)
+
+
+#=================================================================
+def create_cache(redis_url_key=None):
+    if redis_url_key:
+        return RedisCache(redis_url_key)
+
     if uwsgi_cache:  # pragma: no cover
         return UwsgiCache()
     else:

--- a/pywb/framework/proxy.py
+++ b/pywb/framework/proxy.py
@@ -10,11 +10,14 @@ import socket
 import ssl
 
 from pywb.rewrite.url_rewriter import SchemeOnlyUrlRewriter
+from pywb.rewrite.rewrite_content import RewriteContent
 from pywb.utils.wbexception import BadRequestException
 
 from pywb.utils.bufferedreaders import BufferedReader
 
 from pywb.framework.proxy_resolvers import ProxyAuthResolver, CookieResolver, IPCacheResolver
+
+from tempfile import SpooledTemporaryFile
 
 
 #=================================================================
@@ -55,6 +58,7 @@ class ProxyRouter(object):
 
     BLOCK_SIZE = 4096
     DEF_MAGIC_NAME = 'pywb.proxy'
+    BUFF_RESPONSE_MEM_SIZE = 1024*1024
 
     CERT_DL_PEM = '/pywb-ca.pem'
     CERT_DL_P12 = '/pywb-ca.p12'
@@ -222,11 +226,62 @@ class ProxyRouter(object):
             wbrequest.wb_url.mod = 'uo_'
 
         response = route.handler(wbrequest)
+        if not response:
+            return None
 
+        # add extra headers for replay responses
         if wbrequest.wb_url and wbrequest.wb_url.is_replay():
             response.status_headers.replace_headers(self.extra_headers)
 
+        # check for content-length
+        res = response.status_headers.get_header('content-length')
+        try:
+            if int(res) > 0:
+                return response
+        except:
+            pass
+
+        # need to either chunk or buffer to get content-length
+        if env.get('SERVER_PROTOCOL') == 'HTTP/1.1':
+            response.status_headers.remove_header('content-length')
+            response.status_headers.headers.append(('Transfer-Encoding', 'chunked'))
+            response.body = self._chunk_encode(response.body)
+        else:
+            response.body = self._buffer_response(response.status_headers,
+                                                  response.body)
+
         return response
+
+    @staticmethod
+    def _chunk_encode(orig_iter):
+        for buff in orig_iter:
+            chunk = bytes(buff)
+            if not len(chunk):
+                continue
+            chunk_len = '%X\r\n' % len(chunk)
+            yield chunk_len
+            yield chunk
+            yield '\r\n'
+
+        yield '0\r\n\r\n'
+
+    @staticmethod
+    def _buffer_response(status_headers, iterator):
+        out = SpooledTemporaryFile(ProxyRouter.BUFF_RESPONSE_MEM_SIZE)
+        size = 0
+
+        for buff in iterator:
+            buff = bytes(buff)
+            size += len(buff)
+            out.write(buff)
+
+        content_length_str = str(size)
+        # remove existing content length
+        status_headers.replace_header('Content-Length',
+                                      content_length_str)
+
+        out.seek(0)
+        return RewriteContent.stream_to_gen(out)
 
     def get_request_socket(self, env):
         if not self.ca:
@@ -259,7 +314,8 @@ class ProxyRouter(object):
             return WbResponse.text_response('HTTPS Proxy Not Supported',
                                             '405 HTTPS Proxy Not Supported')
 
-        sock.send('HTTP/1.0 200 Connection Established\r\n')
+        sock.send('HTTP/1.1 200 Connection Established\r\n')
+        sock.send('Proxy-Connection: close\r\n')
         sock.send('Server: pywb proxy\r\n')
         sock.send('\r\n')
 

--- a/pywb/framework/proxy.py
+++ b/pywb/framework/proxy.py
@@ -314,7 +314,7 @@ class ProxyRouter(object):
             return WbResponse.text_response('HTTPS Proxy Not Supported',
                                             '405 HTTPS Proxy Not Supported')
 
-        sock.send('HTTP/1.1 200 Connection Established\r\n')
+        sock.send('HTTP/1.0 200 Connection Established\r\n')
         sock.send('Proxy-Connection: close\r\n')
         sock.send('Server: pywb proxy\r\n')
         sock.send('\r\n')

--- a/pywb/framework/proxy.py
+++ b/pywb/framework/proxy.py
@@ -9,7 +9,7 @@ import base64
 import socket
 import ssl
 
-from pywb.rewrite.url_rewriter import HttpsUrlRewriter
+from pywb.rewrite.url_rewriter import SchemeOnlyUrlRewriter
 from pywb.utils.wbexception import BadRequestException
 
 from pywb.utils.bufferedreaders import BufferedReader
@@ -204,7 +204,7 @@ class ProxyRouter(object):
                               host_prefix=host_prefix,
                               rel_prefix=rel_prefix,
                               wburl_class=route.handler.get_wburl_type(),
-                              urlrewriter_class=HttpsUrlRewriter,
+                              urlrewriter_class=SchemeOnlyUrlRewriter,
                               use_abs_prefix=False,
                               is_proxy=True)
 
@@ -219,7 +219,7 @@ class ProxyRouter(object):
             wbrequest.wb_url.mod = 'bn_'
         else:
         # unaltered, no rewrite or banner
-            wbrequest.wb_url.mod = 'id_'
+            wbrequest.wb_url.mod = 'uo_'
 
         response = route.handler(wbrequest)
 

--- a/pywb/framework/wsgi_wrappers.py
+++ b/pywb/framework/wsgi_wrappers.py
@@ -168,7 +168,7 @@ def start_wsgi_ref_server(the_app, name, port):  # pragma: no cover
     import wsgiref.handlers
     wsgiref.handlers.is_hop_by_hop = lambda x: False
 
-    if not port:
+    if port is None:
         port = DEFAULT_PORT
 
     logging.info('Starting %s on port %s', name, port)

--- a/pywb/rewrite/rewrite_content.py
+++ b/pywb/rewrite/rewrite_content.py
@@ -1,5 +1,6 @@
 #import chardet
 import pkgutil
+import webencodings
 import yaml
 import re
 
@@ -164,7 +165,7 @@ class RewriteContent:
 
                 if charset:
                     try:
-                        head_insert_str = head_insert_orig.encode(charset)
+                        head_insert_str = webencodings.encode(head_insert_orig, charset)
                     except:
                         pass
 

--- a/pywb/rewrite/rewrite_content.py
+++ b/pywb/rewrite/rewrite_content.py
@@ -16,6 +16,8 @@ from pywb.utils.statusandheaders import StatusAndHeaders
 from pywb.utils.bufferedreaders import DecompressingBufferedReader
 from pywb.utils.bufferedreaders import ChunkedDataReader, BufferedReader
 
+from regex_rewriters import JSNoneRewriter, JSLinkOnlyRewriter
+
 
 #=================================================================
 class RewriteContent:
@@ -159,9 +161,8 @@ class RewriteContent:
                 charset = self._extract_html_charset(first_buff,
                                                      status_headers)
 
-            if head_insert_func:
+            if head_insert_func and not wb_url.is_url_rewrite_only:
                 head_insert_orig = head_insert_func(rule, cdx)
-                head_insert_str = None
 
                 if charset:
                     try:
@@ -191,9 +192,15 @@ class RewriteContent:
 
                 return (status_headers, gen, False)
 
+            js_rewriter_class = rule.rewriters['js']
+            css_rewriter_class = rule.rewriters['css']
+
+            if wb_url.is_url_rewrite_only:
+                js_rewriter_class = JSNoneRewriter
+
             rewriter = rewriter_class(urlrewriter,
-                                      js_rewriter_class=rule.rewriters['js'],
-                                      css_rewriter_class=rule.rewriters['css'],
+                                      js_rewriter_class=js_rewriter_class,
+                                      css_rewriter_class=css_rewriter_class,
                                       head_insert=head_insert_str,
                                       url=wb_url.url,
                                       defmod=self.defmod,
@@ -202,6 +209,11 @@ class RewriteContent:
         else:
             if wb_url.is_banner_only:
                 return (status_headers, self.stream_to_gen(stream), False)
+
+            # url-only rewriter, but not rewriting urls in JS, so return
+            if wb_url.is_url_rewrite_only and text_type == 'js':
+                #return (status_headers, self.stream_to_gen(stream), False)
+                rewriter_class = JSLinkOnlyRewriter
 
             # apply one of (js, css, xml) rewriters
             rewriter = rewriter_class(urlrewriter)

--- a/pywb/rewrite/rewrite_live.py
+++ b/pywb/rewrite/rewrite_live.py
@@ -284,7 +284,6 @@ class YoutubeDLWrapper(object):  #pragma: no cover
         self.ydl.add_default_info_extractors()
 
     def extract_info(self, url):
-        print('YDL', self.ydl)
         if not self.ydl:
             return None
 

--- a/pywb/rewrite/test/test_rewrite_live.py
+++ b/pywb/rewrite/test/test_rewrite_live.py
@@ -203,7 +203,7 @@ def test_example_1():
     status_headers, buff = get_rewritten('http://example.com/', urlrewriter, req_headers={'Connection': 'close'})
 
     # verify header rewriting
-    assert (('X-Archive-Orig-Content-Length', '1270') in status_headers.headers), status_headers
+    assert status_headers.get_header('x-archive-orig-content-length') == '1270', status_headers
 
 
     # verify utf-8 charset detection

--- a/pywb/rewrite/test/test_rewrite_live.py
+++ b/pywb/rewrite/test/test_rewrite_live.py
@@ -200,7 +200,7 @@ def test_local_unclosed_script():
 
 
 def test_example_1():
-    status_headers, buff = get_rewritten('http://example.com/', urlrewriter, req_headers={'Connection': 'close'})
+    status_headers, buff = get_rewritten('http://example.com/', urlrewriter, req_headers={'Connection': 'close', 'Accept-Encoding': 'identity'})
 
     # verify header rewriting
     assert status_headers.get_header('x-archive-orig-content-length') == '1270', status_headers

--- a/pywb/rewrite/test/test_url_rewriter.py
+++ b/pywb/rewrite/test/test_url_rewriter.py
@@ -125,22 +125,33 @@
 >>> do_deprefix('http://example.com/file.html?foo=bar&url=' + urllib.quote_plus('http://localhost:8080/pywb/extra/path/http://example.com/filename.html') + '&foo2=bar2', '/pywb/', 'http://localhost:8080/pywb/')
 'http://example.com/file.html?foo=bar&url=http://example.com/filename.html&foo2=bar2'
 
-# HttpsUrlRewriter tests
->>> httpsrewriter = HttpsUrlRewriter('http://example.com/', None)
->>> httpsrewriter.rewrite('https://example.com/abc')
+# SchemeOnlyUrlRewriter tests
+>>> SchemeOnlyUrlRewriter('http://example.com/').rewrite('https://example.com/abc')
 'http://example.com/abc'
 
->>> httpsrewriter.rewrite('http://example.com/abc')
+>>> SchemeOnlyUrlRewriter('http://example.com/abc').rewrite('http://example.com/abc')
 'http://example.com/abc'
+
+>>> SchemeOnlyUrlRewriter('https://example.com/abc').rewrite('http://example.com/abc')
+'https://example.com/abc'
+
+>>> SchemeOnlyUrlRewriter('https://example.com/abc').rewrite('https://example.com/abc')
+'https://example.com/abc'
+
+>>> SchemeOnlyUrlRewriter('http://example.com/abc').rewrite('//example.com/abc')
+'//example.com/abc'
+
+>>> SchemeOnlyUrlRewriter('https://example.com/abc').rewrite('//example.com/abc')
+'//example.com/abc'
 
 # rebase is identity
->>> httpsrewriter.rebase_rewriter('https://example.com/') == httpsrewriter
+>>> x = SchemeOnlyUrlRewriter('http://example.com'); x.rebase_rewriter('https://example.com/') == x
 True
 
 """
 
 
-from pywb.rewrite.url_rewriter import UrlRewriter, HttpsUrlRewriter
+from pywb.rewrite.url_rewriter import UrlRewriter, SchemeOnlyUrlRewriter
 import urllib
 
 def do_rewrite(rel_url, base_url, prefix, mod=None, full_prefix=None):

--- a/pywb/rewrite/wburl.py
+++ b/pywb/rewrite/wburl.py
@@ -326,6 +326,10 @@ class WbUrl(BaseWbUrl):
         return (self.mod == 'bn_')
 
     @property
+    def is_url_rewrite_only(self):
+        return (self.mod == 'uo_')
+
+    @property
     def is_identity(self):
         return (self.mod == 'id_')
 

--- a/pywb/static/scroll-webkit.css
+++ b/pywb/static/scroll-webkit.css
@@ -1,0 +1,83 @@
+::-webkit-scrollbar {
+height: 12px;
+overflow: visible;
+width: 12px
+}
+::-webkit-scrollbar-button {
+height: 0;
+width: 0
+}
+::-webkit-scrollbar-track {
+background-clip: padding-box;
+border: solid transparent;
+border-width: 0 0 0 0px
+}
+::-webkit-scrollbar-track:horizontal {
+border-width: 4px 0 0
+}
+::-webkit-scrollbar-track:hover {
+background-color: rgba(0, 0, 0, .05);
+box-shadow: inset 1px 0 0 rgba(0, 0, 0, .1)
+}
+::-webkit-scrollbar-track:horizontal:hover {
+box-shadow: inset 0 1px 0 rgba(0, 0, 0, .1)
+}
+::-webkit-scrollbar-track:active {
+background-color: rgba(0, 0, 0, .05);
+box-shadow: inset 1px 0 0 rgba(0, 0, 0, .14), inset -1px 0 0 rgba(0, 0, 0, .07)
+}
+::-webkit-scrollbar-track:horizontal:active {
+box-shadow: inset 0 1px 0 rgba(0, 0, 0, .14), inset 0 -1px 0 rgba(0, 0, 0, .07)
+}
+::-webkit-scrollbar-thumb {
+background-color: rgba(0, 0, 0, .2);
+background-clip: padding-box;
+border: solid transparent;
+border-width: 1px 1px 1px 2px;
+min-height: 28px;
+padding: 100px 0 0;
+box-shadow: inset 1px 1px 0 rgba(0, 0, 0, .1), inset 0 -1px 0 rgba(0, 0, 0, .07)
+}
+::-webkit-scrollbar-thumb:horizontal {
+border-width: 6px 1px 1px;
+padding: 0 0 0 100px;
+box-shadow: inset 1px 1px 0 rgba(0, 0, 0, .1), inset -1px 0 0 rgba(0, 0, 0, .07)
+}
+::-webkit-scrollbar-thumb:hover {
+background-color: rgba(0, 0, 0, .4);
+box-shadow: inset 1px 1px 1px rgba(0, 0, 0, .25)
+}
+::-webkit-scrollbar-thumb:active {
+background-color: rgba(0, 0, 0, 0.5);
+box-shadow: inset 1px 1px 3px rgba(0, 0, 0, 0.35)
+}
+::-webkit-scrollbar-corner {
+background: transparent
+}
+
+/*
+body::-webkit-scrollbar-track-piece {
+background-clip: padding-box;
+background-color: #f5f5f5;
+border: solid #fff;
+border-width: 0 0 0 3px;
+box-shadow: inset 1px 0 0 rgba(0, 0, 0, .14), inset -1px 0 0 rgba(0, 0, 0, .07)
+}
+body::-webkit-scrollbar-track-piece:horizontal {
+border-width: 3px 0 0;
+box-shadow: inset 0 1px 0 rgba(0, 0, 0, .14), inset 0 -1px 0 rgba(0, 0, 0, .07)
+}
+body::-webkit-scrollbar-thumb {
+border-width: 1px 1px 1px 5px
+}
+body::-webkit-scrollbar-thumb:horizontal {
+border-width: 5px 1px 1px
+}
+body::-webkit-scrollbar-corner {
+background-clip: padding-box;
+background-color: #f5f5f5;
+border: solid #fff;
+border-width: 3px 0 0 3px;
+box-shadow: inset 1px 1px 0 rgba(0, 0, 0, .14)
+}
+*/

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -762,7 +762,7 @@ var wombat_internal = function($wbwindow) {
         def_prop($wbwindow.HTMLBaseElement.prototype, "href", undefined, base_href_get);
 
         // Shared baseURI
-        var orig_getter = get_orig_getter($wbwindow.Node, "baseURI");
+        var orig_getter = get_orig_getter($wbwindow.Node.prototype, "baseURI");
         if (orig_getter) {
             var get_baseURI = function() {
                 var res = orig_getter.call(this);

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -363,26 +363,31 @@ var wombat_internal = function($wbwindow) {
     }
 
     //============================================
-    // Define custom property
+    // Override a DOM property
     function def_prop(obj, prop, set_func, get_func) {
+        // if the property is marked as non-configurable in the current
+        // browser, skip the override
+        var existingDescriptor = Object.getOwnPropertyDescriptor(obj, prop);
+        if (existingDescriptor && !existingDescriptor.configurable) {
+            return;
+        }
+
+        // if no getter function was supplied, skip the override.
+        // See https://github.com/ikreymer/pywb/issues/147 for context
+        if (!get_func) {
+            return;
+        }
+
         try {
             Object.defineProperty(obj, prop, {
                 configurable: false,
-//                enumerable: true,
                 set: set_func,
                 get: get_func
             });
 
             return true;
         } catch (e) {
-            var info = "Can't redefine prop " + prop;
-            console.warn(info);
-            //f (obj && obj.tagName) {
-            //    info += " on " + obj.tagName;
-            //}
-            //if (value != obj[prop]) {
-            //    obj[prop] = value;
-            //}
+            console.warn('Failed to redefine property %s', prop, e.message);
             return false;
         }
     }
@@ -757,15 +762,16 @@ var wombat_internal = function($wbwindow) {
         def_prop($wbwindow.HTMLBaseElement.prototype, "href", undefined, base_href_get);
 
         // Shared baseURI
-        var orig_getter = $wbwindow.document.__lookupGetter__("baseURI");
+        var orig_getter = get_orig_getter($wbwindow.Node, "baseURI");
+        if (orig_getter) {
+            var get_baseURI = function() {
+                var res = orig_getter.call(this);
+                return extract_orig(res);
+            }
 
-        var get_baseURI = function() {
-            var res = orig_getter.call(this);
-            return extract_orig(res);
+            def_prop($wbwindow.HTMLElement.prototype, "baseURI", undefined, get_baseURI);
+            def_prop($wbwindow.HTMLDocument.prototype, "baseURI", undefined, get_baseURI);
         }
-
-        def_prop($wbwindow.HTMLElement.prototype, "baseURI", undefined, get_baseURI);
-        def_prop($wbwindow.HTMLDocument.prototype, "baseURI", undefined, get_baseURI);
     }
 
     //============================================

--- a/pywb/templates/collinfo.json
+++ b/pywb/templates/collinfo.json
@@ -1,0 +1,15 @@
+[
+{% for route in routes %}
+{% if route | is_wb_handler %}
+{{ ',' if notfirst else '' }}
+{
+    "id": "{{ route.path }}",
+    "name": "{{ route.user_metadata.title if route.user_metadata.title else route.path }}", 
+    "timegate": "{{ host }}/{{route.path}}/",
+    "timemap": "{{ host }}/{{route.path}}/timemap/*/"
+
+}
+{% set notfirst = true %}
+{% endif %}
+{% endfor %}
+]

--- a/pywb/templates/frame_insert.html
+++ b/pywb/templates/frame_insert.html
@@ -23,6 +23,7 @@ html, body
 </script>
 <script src='{{ wbrequest.host_prefix }}/{{ static_path }}/wb.js'> </script>
 <link rel='stylesheet' href='{{ wbrequest.host_prefix }}/{{ static_path }}/wb.css'/>
+<link rel='stylesheet' href='{{ wbrequest.host_prefix }}/{{ static_path }}/scroll-webkit.css'/>
 
 {% include banner_html ignore missing %}
 
@@ -30,7 +31,7 @@ html, body
 </head>
 <body style="margin: 0px; padding: 0px;">
 <div class="wb_iframe_div">
-<iframe id="replay_iframe" src="{{ wbrequest.wb_prefix + embed_url }}" onload="iframe_loaded(event);" seamless="seamless" frameborder="0" scrolling="yes" class="wb_iframe"></iframe>
+<iframe id="replay_iframe" src="{{ wbrequest.wb_prefix + embed_url }}" onload="iframe_loaded(event);" frameborder="0" seamless="seamless" scrolling="yes" class="wb_iframe"></iframe>
 </div>
 </body>
 </html>

--- a/pywb/warc/cdxindexer.py
+++ b/pywb/warc/cdxindexer.py
@@ -3,10 +3,22 @@ import sys
 
 # Use ujson if available
 try:
-    from ujson import dumps as json_encode
-except:
-    from json import dumps as json_encode
+    from ujson import dumps as ujson_dumps
 
+    try:
+        assert (ujson_dumps('http://example.com/',
+                            escape_forward_slashes=False) ==
+                '"http://example.com/"')
+    except Exception as e:  # pragma: no cover
+        sys.stderr.write('ujson w/o forward-slash escaping not available,\
+defaulting to regular json\n')
+        raise
+
+    def json_encode(obj):
+        return ujson_dumps(obj, escape_forward_slashes=False)
+
+except:  # pragma: no cover
+    from json import dumps as json_encode
 
 try:  # pragma: no cover
     from collections import OrderedDict

--- a/pywb/webapp/live_rewrite_handler.py
+++ b/pywb/webapp/live_rewrite_handler.py
@@ -11,7 +11,6 @@ from views import HeadInsertView
 from pywb.utils.wbexception import WbException
 
 import json
-import requests
 import hashlib
 
 
@@ -28,8 +27,6 @@ class RewriteHandler(SearchPageWbUrlHandler):
 
     YT_DL_TYPE = 'application/vnd.youtube-dl_formats+json'
 
-    youtubedl = None
-
     def __init__(self, config):
         super(RewriteHandler, self).__init__(config)
 
@@ -37,10 +34,10 @@ class RewriteHandler(SearchPageWbUrlHandler):
 
         live_rewriter_cls = config.get('live_rewriter_cls', LiveRewriter)
 
-        self.rewriter = live_rewriter_cls(is_framed_replay=self.is_frame_mode,
-                                          proxies=proxyhostport)
+        self.live_fetcher = live_rewriter_cls(is_framed_replay=self.is_frame_mode,
+                                              proxies=proxyhostport)
 
-        self.proxies = self.rewriter.proxies
+        self.recording = self.live_fetcher.is_recording()
 
         self.head_insert_view = HeadInsertView.init_from_config(config)
 
@@ -73,7 +70,7 @@ class RewriteHandler(SearchPageWbUrlHandler):
     def _live_request_headers(self, wbrequest):
         return {}
 
-    def _ignore_proxies(self, wbrequest):
+    def _skip_recording(self, wbrequest):
         return False
 
     def render_content(self, wbrequest):
@@ -87,7 +84,7 @@ class RewriteHandler(SearchPageWbUrlHandler):
         if ref_wburl_str:
             wbrequest.env['REL_REFERER'] = WbUrl(ref_wburl_str).url
 
-        ignore_proxies = self._ignore_proxies(wbrequest)
+        skip_recording = self._skip_recording(wbrequest)
 
         use_206 = False
         url = None
@@ -96,7 +93,7 @@ class RewriteHandler(SearchPageWbUrlHandler):
         readd_range = False
         cache_key = None
 
-        if self.proxies and not ignore_proxies:
+        if self.recording and not skip_recording:
             rangeres = wbrequest.extract_range()
 
             if rangeres:
@@ -110,17 +107,17 @@ class RewriteHandler(SearchPageWbUrlHandler):
                     readd_range = True
                 else:
                     # disables proxy
-                    ignore_proxies = True
+                    skip_recording = True
 
                     # sets cache_key only if not already cached
                     cache_key = self._get_cache_key('r:', url)
 
-        result = self.rewriter.fetch_request(wbrequest.wb_url.url,
+        result = self.live_fetcher.fetch_request(wbrequest.wb_url.url,
                                              wbrequest.urlrewriter,
                                              head_insert_func=head_insert_func,
                                              req_headers=req_headers,
                                              env=wbrequest.env,
-                                             ignore_proxies=ignore_proxies,
+                                             skip_recording=skip_recording,
                                              verify=self.verify)
 
         wbresponse = self._make_response(wbrequest, *result)
@@ -135,8 +132,8 @@ class RewriteHandler(SearchPageWbUrlHandler):
             except (ValueError, TypeError):
                 pass
 
-        if cache_key:
-            self._add_proxy_ping(cache_key, url, wbrequest, wbresponse)
+        if self.recording and cache_key:
+            self._add_rec_ping(cache_key, url, wbrequest, wbresponse)
 
         if rangeres:
             referrer = wbrequest.env.get('REL_REFERER')
@@ -183,7 +180,7 @@ class RewriteHandler(SearchPageWbUrlHandler):
         key = prefix + key
         return key
 
-    def _add_proxy_ping(self, key, url, wbrequest, wbresponse):
+    def _add_rec_ping(self, key, url, wbrequest, wbresponse):
         def do_ping():
             headers = self._live_request_headers(wbrequest)
             headers['Connection'] = 'close'
@@ -192,15 +189,8 @@ class RewriteHandler(SearchPageWbUrlHandler):
                 # mark as pinged
                 self._cache[key] = '1'
 
-                resp = requests.get(url=url,
-                                    headers=headers,
-                                    proxies=self.proxies,
-                                    verify=False,
-                                    stream=True)
+                self.live_fetcher.fetch_async(url, headers)
 
-                # don't actually read whole response,
-                # proxy response for writing it
-                resp.close()
             except:
                 del self._cache[key]
                 raise
@@ -219,9 +209,6 @@ class RewriteHandler(SearchPageWbUrlHandler):
         return wbresponse
 
     def _get_video_info(self, wbrequest, info_url=None, video_url=None):
-        if not self.youtubedl:
-            self.youtubedl = YoutubeDLWrapper()
-
         if not video_url:
             video_url = wbrequest.wb_url.url
 
@@ -229,10 +216,10 @@ class RewriteHandler(SearchPageWbUrlHandler):
             info_url = wbrequest.wb_url.url
 
         cache_key = None
-        if self.proxies:
+        if self.recording:
             cache_key = self._get_cache_key('v:', video_url)
 
-        info = self.youtubedl.extract_info(video_url)
+        info = self.live_fetcher.get_video_info(video_url)
         if info is None:  #pragma: no cover
             msg = ('youtube-dl is not installed, pip install youtube-dl to ' +
                    'enable improved video proxy')
@@ -244,42 +231,14 @@ class RewriteHandler(SearchPageWbUrlHandler):
         content_type = self.YT_DL_TYPE
         metadata = json.dumps(info)
 
-        if (self.proxies and cache_key):
+        if (self.recording and cache_key):
             headers = self._live_request_headers(wbrequest)
             headers['Content-Type'] = content_type
 
             info_url = HttpsUrlRewriter.remove_https(info_url)
 
-            response = requests.request(method='PUTMETA',
-                                        url=info_url,
-                                        data=metadata,
-                                        headers=headers,
-                                        proxies=self.proxies,
-                                        verify=False)
+            response = self.live_fetcher.add_metadata(info_url, headers, metadata)
 
             self._cache[cache_key] = '1'
 
         return WbResponse.text_response(metadata, content_type=content_type)
-
-
-#=================================================================
-class YoutubeDLWrapper(object):  #pragma: no cover
-    """ YoutubeDL wrapper, inits youtubee-dl if it is available
-    """
-    def __init__(self):
-        try:
-            from youtube_dl import YoutubeDL as YoutubeDL
-        except ImportError:
-            self.ydl = None
-            return
-
-        self.ydl = YoutubeDL(dict(simulate=True,
-                                  youtube_include_dash_manifest=False))
-        self.ydl.add_default_info_extractors()
-
-    def extract_info(self, url):
-        if not self.ydl:
-            return None
-
-        info = self.ydl.extract_info(url)
-        return info

--- a/pywb/webapp/live_rewrite_handler.py
+++ b/pywb/webapp/live_rewrite_handler.py
@@ -3,7 +3,6 @@ from pywb.framework.cache import create_cache
 
 from pywb.rewrite.rewrite_live import LiveRewriter
 from pywb.rewrite.wburl import WbUrl
-from pywb.rewrite.url_rewriter import HttpsUrlRewriter
 
 from handlers import StaticHandler, SearchPageWbUrlHandler
 from views import HeadInsertView
@@ -235,7 +234,8 @@ class RewriteHandler(SearchPageWbUrlHandler):
             headers = self._live_request_headers(wbrequest)
             headers['Content-Type'] = content_type
 
-            info_url = HttpsUrlRewriter.remove_https(info_url)
+            if info_url.startswith('https://'):
+                info_url = info_url.replace('https', 'http', 1)
 
             response = self.live_fetcher.add_metadata(info_url, headers, metadata)
 

--- a/pywb/webapp/pywb_init.py
+++ b/pywb/webapp/pywb_init.py
@@ -381,5 +381,6 @@ def create_wb_router(passed_config=None):
         abs_path=config.get('absolute_paths', True),
         home_view=init_view(config, 'home_html'),
         error_view=init_view(config, 'error_html'),
+        info_view=init_view(config, 'info_json'),
         config=config
     )

--- a/pywb/webapp/replay_views.py
+++ b/pywb/webapp/replay_views.py
@@ -187,12 +187,7 @@ class ReplayView(object):
                 content_len = 0
 
             if content_len <= 0:
-                # if proxy mode, must set content-length (or use chunked)
-                if wbrequest.options.get('is_proxy'):
-                    max_size = 0
-                else:
-                    max_size = self.buffer_max_size
-
+                max_size = self.buffer_max_size
                 response_iter = self.buffered_response(status_headers,
                                                        response_iter,
                                                        max_size)

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,8 @@ setup(
         'jinja2',
         'surt',
         'pyyaml',
-        'watchdog'
+        'watchdog',
+        'webencodings',
        ],
     tests_require=[
         'pytest',

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,12 @@ long_description = open('README.rst').read()
 class PyTest(TestCommand):
     user_options = []
     def initialize_options(self):
+        TestCommand.initialize_options(self)
         self._argv = []
-        pass
 
     def finalize_options(self):
-        pass
+        TestCommand.finalize_options(self)
+        self.test_suite = True
 
     def run_tests(self):
         import pytest

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,13 @@ long_description = open('README.rst').read()
 
 
 class PyTest(TestCommand):
+    user_options = []
+    def initialize_options(self):
+        self._argv = []
+        pass
+
     def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_suite = True
+        pass
 
     def run_tests(self):
         import pytest
@@ -31,7 +35,9 @@ class PyTest(TestCommand):
         os.environ.pop('PYWB_CONFIG_FILE', None)
         cmdline = ' --cov-config .coveragerc --cov pywb'
         cmdline += ' -v --doctest-module ./pywb/ tests/'
+
         errcode = pytest.main(cmdline)
+
         sys.exit(errcode)
 
 setup(
@@ -74,7 +80,7 @@ setup(
         'requests',
         'redis',
         'jinja2',
-        'surt',
+        'surt==0.2',
         'pyyaml',
         'watchdog',
         'webencodings',

--- a/setup.py
+++ b/setup.py
@@ -21,13 +21,9 @@ long_description = open('README.rst').read()
 
 class PyTest(TestCommand):
     user_options = []
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self._argv = []
-
     def finalize_options(self):
         TestCommand.finalize_options(self)
-        self.test_suite = True
+        self.test_suite = ' '
 
     def run_tests(self):
         import pytest

--- a/tests/server_thread.py
+++ b/tests/server_thread.py
@@ -22,6 +22,7 @@ class ServerThreadRunner(object):
         self.port = self.httpd.socket.getsockname()[1]
 
         proxy_str = 'http://localhost:' + str(self.port)
+        self.proxy_str = proxy_str
         self.proxy_dict = {'http': proxy_str,
                            'https': proxy_str}
 

--- a/tests/test_auto_colls.py
+++ b/tests/test_auto_colls.py
@@ -16,6 +16,7 @@ from pywb.manager.manager import main
 import pywb.manager.autoindex
 
 from pywb.warc.cdxindexer import main as cdxindexer_main
+from pywb.cdx.cdxobject import CDXObject
 
 from pywb import get_test_dir
 from pywb.framework.wsgi_wrappers import init_app
@@ -457,7 +458,11 @@ class TestManagedColls(object):
         assert all(x.endswith('.cdxj') for x in cdxjs)
 
         with open(os.path.join(migrate_dir, 'iana.cdxj')) as fh:
-            assert fh.readline().startswith('org,iana)/ 20140126200624 {"url": "http://www.iana.org/",')
+            cdx = CDXObject(fh.readline())
+            assert cdx['urlkey'] == 'org,iana)/'
+            assert cdx['timestamp'] == '20140126200624'
+            assert cdx['url'] == 'http://www.iana.org/'
+            #assert fh.readline().startswith('org,iana)/ 20140126200624 {"url": "http://www.iana.org/",')
 
         # Nothing else to migrate
         main(['cdx-convert', migrate_dir])

--- a/tests/test_auto_colls.py
+++ b/tests/test_auto_colls.py
@@ -84,17 +84,18 @@ class TestManagedColls(object):
         test autoindex error before collections inited
         """
         from pywb.apps.cli import wayback
-        wayback([])
+
+        wayback(['-p', '0'])
 
         # Nothing to auto-index.. yet
         with raises(SystemExit):
-            wayback(['-a'])
+            wayback(['-a', '-p', '0'])
 
         colls = os.path.join(self.root_dir, 'collections')
         os.mkdir(colls)
 
         pywb.manager.autoindex.keep_running = False
-        wayback(['-a'])
+        wayback(['-a', '-p', '0'])
 
     def test_create_first_coll(self):
         """ Test first collection creation, with all required dirs

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -121,6 +121,10 @@ proxy_options:
     use_client_rewrite: true
     use_wombat: true
 
+
+#enable coll info JSON
+enable_coll_info: true
+
 # enable cdx server api for querying cdx directly (experimental)
 #enable_cdx_api: True
 # or specify suffix

--- a/tests/test_config_proxy_ip_redis.yaml
+++ b/tests/test_config_proxy_ip_redis.yaml
@@ -1,0 +1,21 @@
+collections:
+    all:
+        - ./sample_archive/cdx/iana.cdx
+        - ./sample_archive/cdx/dupes.cdx
+        - ./sample_archive/cdx/post-test.cdx
+
+archive_paths: ./sample_archive/warcs/
+
+enable_http_proxy: true
+
+proxy_options:
+    enable_https_proxy: false
+
+    cookie_resolver: ip
+    redis_cache_key: redis://localhost:6379/0/proxy:hosts
+    redis_cache_timeout: 120
+
+    use_default_coll: all
+
+    use_banner: true
+    use_client_rewrite: false

--- a/tests/test_config_proxy_no_banner.yaml
+++ b/tests/test_config_proxy_no_banner.yaml
@@ -1,0 +1,18 @@
+collections:
+    all:
+        - ./sample_archive/cdx/iana.cdx
+
+archive_paths: ./sample_archive/warcs/
+
+enable_http_proxy: true
+
+buffer_response: false
+
+proxy_options:
+    enable_https_proxy: false
+
+    cookie_resolver: ip
+    use_default_coll: all
+
+    use_banner: false
+    use_client_rewrite: false

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -477,7 +477,13 @@ class TestWbIntegration(BaseIntegration):
         assert resp.status_int == 400
         assert 'Invalid Url: http://?abc' in resp.body
 
-    #def test_invalid_config(self):
+
+    def test_coll_info_json(self):
+        resp = self.testapp.get('/collinfo.json')
+        assert resp.content_type == 'application/json'
+        assert len(resp.json) == 9
+
+   #def test_invalid_config(self):
     #    with raises(IOError):
     #        init_app(create_wb_router,
     #                 load_yaml=True,

--- a/tests/test_live_proxy.py
+++ b/tests/test_live_proxy.py
@@ -10,7 +10,7 @@ from pywb.framework.wsgi_wrappers import init_app
 import webtest
 import shutil
 
-import pywb.webapp.live_rewrite_handler
+import pywb.rewrite.rewrite_live
 
 
 #=================================================================
@@ -53,7 +53,7 @@ class MockYTDWrapper(object):
         return {'mock': 'youtube_dl_data'}
 
 
-pywb.webapp.live_rewrite_handler.YoutubeDLWrapper = MockYTDWrapper
+pywb.rewrite.rewrite_live.youtubedl = MockYTDWrapper()
 
 
 #=================================================================

--- a/tests/test_live_proxy.py
+++ b/tests/test_live_proxy.py
@@ -73,7 +73,7 @@ def setup_module():
 
     config = dict(collections=dict(rewrite='$liveweb'),
                   framed_replay=True,
-                  proxyhostport=server.proxy_dict)
+                  proxyhostport=server.proxy_str)
 
     global cache
     cache = {}

--- a/tests/test_live_rewriter.py
+++ b/tests/test_live_rewriter.py
@@ -2,7 +2,7 @@ from pywb.webapp.live_rewrite_handler import RewriteHandler
 from pywb.apps.cli import LiveCli
 from pywb.framework.wsgi_wrappers import init_app
 import webtest
-import pywb.webapp.live_rewrite_handler
+import pywb.rewrite.rewrite_live
 
 
 #=================================================================
@@ -11,7 +11,7 @@ class MockYTDWrapper(object):
         return {'mock': 'youtube_dl_data'}
 
 
-pywb.webapp.live_rewrite_handler.YoutubeDLWrapper = MockYTDWrapper
+pywb.rewrite.rewrite_live.youtubedl = MockYTDWrapper()
 
 
 def setup_module():

--- a/tests/test_proxy_http_ip.py
+++ b/tests/test_proxy_http_ip.py
@@ -81,3 +81,14 @@ class TestProxyIPResolver(BaseIntegration):
         resp = self.get_url('http://www.iana.org/', '127.0.0.3')
         self._assert_basic_html(resp)
         assert '"20140127171238"' in resp.body
+
+    def test_proxy_ip_delete_ip(self):
+        resp = self.get_url('http://info.pywb.proxy/')
+        assert resp.json == {'ip': '127.0.0.1', 'coll': 'all', 'ts': '1996'}
+
+        resp = self.get_url('http://info.pywb.proxy/set?delete=true')
+        assert resp.json == {'ip': '127.0.0.1', 'coll': None, 'ts': None}
+
+        resp = self.get_url('http://info.pywb.proxy/')
+        assert resp.json == {'ip': '127.0.0.1', 'coll': None, 'ts': None}
+

--- a/tests/test_proxy_http_ip_redis.py
+++ b/tests/test_proxy_http_ip_redis.py
@@ -1,0 +1,98 @@
+from pytest import raises
+import webtest
+import base64
+
+from pywb.webapp.pywb_init import create_wb_router
+from pywb.framework.wsgi_wrappers import init_app
+from pywb.cdx.cdxobject import CDXObject
+
+from urlparse import urlsplit
+
+from server_mock import make_setup_module, BaseIntegration
+
+setup_module = make_setup_module('tests/test_config_proxy_ip_redis.yaml')
+
+from fakeredis import FakeStrictRedis
+
+import pywb.framework.cache
+pywb.framework.cache.StrictRedis = FakeStrictRedis
+
+class TestProxyIPRedisResolver(BaseIntegration):
+    def _assert_basic_html(self, resp):
+        assert resp.status_int == 200
+        assert resp.content_type == 'text/html'
+        assert resp.content_length > 0
+
+    def _assert_basic_text(self, resp):
+        assert resp.status_int == 200
+        assert resp.content_type == 'text/plain'
+        assert resp.content_length > 0
+
+    def get_url(self, uri, addr='127.0.0.1'):
+        parts = urlsplit(uri)
+        env = dict(REQUEST_URI=uri, QUERY_STRING=parts.query, SCRIPT_NAME='', REMOTE_ADDR=addr)
+        # 'Simulating' proxy by settings REQUEST_URI explicitly to full url with empty SCRIPT_NAME
+        return self.testapp.get('/x-ignore-this-x', extra_environ=env)
+
+    def test_proxy_ip_default_ts(self):
+        resp = self.get_url('http://www.iana.org/')
+        self._assert_basic_html(resp)
+
+        assert '"20140127171238"' in resp.body
+        assert 'wb.js' in resp.body
+
+    def test_proxy_ip_get_defaults(self):
+        resp = self.get_url('http://info.pywb.proxy/')
+        assert resp.content_type == 'application/json'
+        assert resp.json == {'ip': '127.0.0.1', 'coll': None, 'ts': None}
+
+    def test_proxy_ip_set_ts(self):
+        resp = self.get_url('http://info.pywb.proxy/set?ts=1996')
+        assert resp.content_type == 'application/json'
+        assert resp.json == {'ip': '127.0.0.1', 'coll': None, 'ts': '1996'}
+
+    def test_proxy_ip_set_ts_coll(self):
+        resp = self.get_url('http://info.pywb.proxy/set?ts=1996&coll=all')
+        assert resp.content_type == 'application/json'
+        assert resp.json == {'ip': '127.0.0.1', 'coll': 'all', 'ts': '1996'}
+
+    def test_proxy_ip_set_ts_coll_diff_ip(self):
+        resp = self.get_url('http://info.pywb.proxy/set?ts=2006&coll=all', '127.0.0.2')
+        assert resp.content_type == 'application/json'
+        assert resp.json == {'ip': '127.0.0.2', 'coll': 'all', 'ts': '2006'}
+
+        # from previous response
+        resp = self.get_url('http://info.pywb.proxy/')
+        assert resp.json == {'ip': '127.0.0.1', 'coll': 'all', 'ts': '1996'}
+
+        resp = self.get_url('http://info.pywb.proxy/set?ip=127.0.0.2&ts=2005')
+        assert resp.json == {'ip': '127.0.0.2', 'coll': 'all', 'ts': '2005'}
+
+        resp = self.get_url('http://info.pywb.proxy/', '127.0.0.2')
+        assert resp.json == {'ip': '127.0.0.2', 'coll': 'all', 'ts': '2005'}
+
+    def test_proxy_ip_change_ts_for_ip(self):
+        resp = self.get_url('http://info.pywb.proxy/set?ip=1.2.3.4&ts=20140126200624')
+        assert resp.json == {'ip': '1.2.3.4', 'coll': None, 'ts': '20140126200624'}
+
+        # different ts for this ip
+        resp = self.get_url('http://www.iana.org/', '1.2.3.4')
+        self._assert_basic_html(resp)
+
+        assert '"20140126200624"' in resp.body
+
+        # defaults for any other ip
+        resp = self.get_url('http://www.iana.org/', '127.0.0.3')
+        self._assert_basic_html(resp)
+        assert '"20140127171238"' in resp.body
+
+    def test_proxy_ip_delete_ip(self):
+        resp = self.get_url('http://info.pywb.proxy/')
+        assert resp.json == {'ip': '127.0.0.1', 'coll': 'all', 'ts': '1996'}
+
+        resp = self.get_url('http://info.pywb.proxy/set?delete=true')
+        assert resp.json == {'ip': '127.0.0.1', 'coll': None, 'ts': None}
+
+        resp = self.get_url('http://info.pywb.proxy/')
+        assert resp.json == {'ip': '127.0.0.1', 'coll': None, 'ts': None}
+

--- a/tests/test_proxy_http_no_banner.py
+++ b/tests/test_proxy_http_no_banner.py
@@ -1,0 +1,48 @@
+from pytest import raises
+import webtest
+import base64
+
+from pywb.webapp.pywb_init import create_wb_router
+from pywb.framework.wsgi_wrappers import init_app
+from pywb.cdx.cdxobject import CDXObject
+
+from urlparse import urlsplit
+
+from server_mock import make_setup_module, BaseIntegration
+
+setup_module = make_setup_module('tests/test_config_proxy_no_banner.yaml')
+
+class TestProxyNoBanner(BaseIntegration):
+    def get_url(self, uri, addr='127.0.0.1', server_protocol='HTTP/1.0'):
+        parts = urlsplit(uri)
+        env = dict(REQUEST_URI=uri, QUERY_STRING=parts.query, SCRIPT_NAME='',
+                   SERVER_PROTOCOL=server_protocol, REMOTE_ADDR=addr)
+        # 'Simulating' proxy by settings REQUEST_URI explicitly to full url with empty SCRIPT_NAME
+        return self.testapp.get('/x-ignore-this-x', extra_environ=env)
+
+    def test_proxy_chunked(self):
+        resp = self.get_url('http://www.iana.org/_img/2013.1/icann-logo.svg', server_protocol='HTTP/1.1')
+        assert resp.content_type == 'image/svg+xml'
+        assert resp.headers['Transfer-Encoding'] == 'chunked'
+        assert int(resp.headers['Content-Length']) == len(resp.body)
+
+    def test_proxy_buffered(self):
+        resp = self.get_url('http://www.iana.org/_img/2013.1/icann-logo.svg', server_protocol='HTTP/1.0')
+        assert resp.content_type == 'image/svg+xml'
+        assert 'Transfer-Encoding' not in resp.headers
+        assert int(resp.headers['Content-Length']) == len(resp.body)
+
+    def test_proxy_html_url_only_rewrite_buffered(self):
+        resp = self.get_url('http://www.iana.org/', server_protocol='HTTP/1.0')
+        assert 'Transfer-Encoding' not in resp.headers
+        assert int(resp.headers['Content-Length']) == len(resp.body)
+
+    def test_proxy_js_url_only_rewrite_buffered(self):
+        resp = self.get_url('http://www.iana.org/_js/2013.1/iana.js', server_protocol='HTTP/1.0')
+        assert 'Transfer-Encoding' not in resp.headers
+        assert int(resp.headers['Content-Length']) == len(resp.body)
+
+    def test_proxy_js_url_only_rewrite_chunked(self):
+        resp = self.get_url('http://www.iana.org/_js/2013.1/iana.js', server_protocol='HTTP/1.1')
+        assert resp.headers['Transfer-Encoding'] == 'chunked'
+        assert int(resp.headers['Content-Length']) == len(resp.body)


### PR DESCRIPTION
Enable testing against Safari on Sauce Labs

 * Provide a fallback mode in the Karma tests which tests
   against a local browser (defaults to Firefox) if Sauce Labs
   credentials are not set.

   This is useful for local testing for contributors who
   might not have a Sauce Labs account.

 * Add Safari under OS X to the set of Sauce Labs browsers
   that the Karma tests are run against, following the merge
   of the WombatJS fixes for Safari and Edge.

   Although Edge now works under manual testing, automated
   testing against Sauce Labs is not yet working for reasons
   yet to be determined.
