### PR TITLE
Enable testing against Safari on Sauce Labs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ python:
 os:
   - linux
 
+addons:
+  sauce_connect: true
+
 cache:
   directories:
     - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ install:
   - pip install coverage pytest-cov coveralls --use-mirrors
   - npm install
 
+before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
 script:
   - python setup.py test
   - cd karma-tests && make test

--- a/karma-tests/karma.conf.js
+++ b/karma-tests/karma.conf.js
@@ -1,8 +1,3 @@
-if (!process.env['SAUCE_USERNAME'] || !process.env['SAUCE_ACCESS_KEY']) {
-    console.error('Sauce Labs account details not set, skipping Karma tests');
-    process.exit(0);
-}
-
 var sauceLabsConfig = {
     testName: 'PyWB Client Tests',
 };
@@ -15,7 +10,7 @@ if (process.env.TRAVIS_JOB_NUMBER) {
 
 var WOMBAT_JS_PATH = 'pywb/static/wombat.js';
 
-var customLaunchers = {
+var sauceLaunchers = {
     sl_chrome: {
         base: 'SauceLabs',
         browserName: 'chrome',
@@ -26,24 +21,44 @@ var customLaunchers = {
         browserName: 'firefox',
     },
 
-/*  Safari and Edge are currently broken in
-    pywb.
-
-    See: https://github.com/ikreymer/pywb/issues/148 (Edge)
-         https://github.com/ikreymer/pywb/issues/147 (Safari)
-
     sl_safari: {
         base: 'SauceLabs',
         browserName: 'safari',
         platform: 'OS X 10.11',
         version: '9.0',
     },
+
+/*  Edge is currently broken in
+    pywb.
+
+    See: https://github.com/ikreymer/pywb/issues/148 (Edge)
+         https://github.com/ikreymer/pywb/issues/147 (Safari)
+
+
     sl_edge: {
         base: 'SauceLabs',
         browserName: 'MicrosoftEdge',
     },
 */
 };
+
+var localLaunchers = {
+    localFirefox: {
+        base: 'Firefox',
+    },
+};
+
+var customLaunchers = {};
+
+if (process.env['SAUCE_USERNAME'] && process.env['SAUCE_ACCESS_KEY']) {
+    customLaunchers = sauceLaunchers;
+} else {
+    console.error('Sauce Labs account details not set, ' +
+                  'Karma tests will be run only against local browsers.' +
+                  'Set SAUCE_USERNAME and SAUCE_ACCESS_KEY environment variables to ' +
+                  'run tests against Sauce Labs browsers');
+    customLaunchers = localLaunchers;
+}
 
 module.exports = function(config) {
   config.set({

--- a/karma-tests/wombat.spec.js
+++ b/karma-tests/wombat.spec.js
@@ -44,8 +44,21 @@ function runWombatTest(testCase, done) {
             };
 
             // expose chai's assertion testing API to the test script
-            assert = window.parent.assert;
-            reportError = window.parent.reportError;
+            window.assert = window.parent.assert;
+            window.reportError = window.parent.reportError;
+
+            // helpers which check whether DOM property overrides are supported
+            // in the current browser
+            window.domTests = {
+                areDOMPropertiesConfigurable: function () {
+                    var descriptor = Object.getOwnPropertyDescriptor(Node.prototype, 'baseURI');
+                    if (descriptor && !descriptor.configurable) {
+                        return false;
+                    } else {
+                        return true;
+                    }
+                }
+            };
         });
 
         try {
@@ -123,7 +136,9 @@ describe('WombatJS', function () {
                 if (typeof baseURI !== 'string') {
                     throw new Error('baseURI is not a string');
                 }
-                assert.equal(baseURI, 'http:///dummy.html');
+                if (domTests.areDOMPropertiesConfigurable()) {
+                    assert.equal(baseURI, 'http:///dummy.html');
+                }
             },
         }, done);
     });
@@ -141,7 +156,9 @@ describe('WombatJS', function () {
             html: '<a href="foobar.html" id="link">A link</a>',
             testScript: function () {
                 var link = document.getElementById('link');
-                assert.equal(link.href, 'http:///foobar.html');
+                if (domTests.areDOMPropertiesConfigurable()) {
+                    assert.equal(link.href, 'http:///foobar.html');
+                }
             },
         }, done);
     });

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -762,7 +762,7 @@ var wombat_internal = function($wbwindow) {
         def_prop($wbwindow.HTMLBaseElement.prototype, "href", undefined, base_href_get);
 
         // Shared baseURI
-        var orig_getter = get_orig_getter($wbwindow.Node, "baseURI");
+        var orig_getter = get_orig_getter($wbwindow.Node.prototype, "baseURI");
         if (orig_getter) {
             var get_baseURI = function() {
                 var res = orig_getter.call(this);


### PR DESCRIPTION
(This PR also includes https://github.com/ikreymer/pywb/pull/154, which is necessary for the tests to pass)

* Provide a fallback mode in the Karma tests which tests
  against a local browser (defaults to Firefox) if Sauce Labs
  credentials are not set.
  This is useful for local testing for contributors who
  might not have a Sauce Labs account.
* Add Safari under OS X to the set of Sauce Labs browsers
  that the Karma tests are run against, following the merge
  of the WombatJS fixes for Safari and Edge.

Although Edge now works under manual testing, automated testing against Edge via Sauce Labs is not yet working for reasons yet to be determined.

