### PR TITLE
Override HTMLAnchorElement.prototype.toString()

### DIFF
--- a/karma-tests/wombat.spec.js
+++ b/karma-tests/wombat.spec.js
@@ -34,7 +34,6 @@ function runWombatTest(testCase, done) {
         window.assert = {
             equal: function (a, b) {
                 if (a !== b) {
-                    x.equal(a, b);
                     console.error('Mismatch between', a, 'and', b);
                     throw new Error('AssertionError');
                 }
@@ -133,8 +132,9 @@ describe('WombatJS', function () {
     });
 
     describe('anchor rewriting', function () {
-        it('should rewrite links in dynamically injected <a> tags', function (done) {
-            runWombatTest({
+        var config;
+        beforeEach(function () {
+            config = {
                 initScript: function () {
                     wbinfo = {
                         wombat_opts: {},
@@ -144,13 +144,28 @@ describe('WombatJS', function () {
                 },
                 wombatScript: wombatScript,
                 html: '<a href="foobar.html" id="link">A link</a>',
-                testScript: function () {
+            };
+        });
+
+        it('should rewrite links in dynamically injected <a> tags', function (done) {
+            config.testScript = function () {
+                if (domTests.areDOMPropertiesConfigurable()) {
                     var link = document.getElementById('link');
-                    if (domTests.areDOMPropertiesConfigurable()) {
-                        assert.equal(link.href, 'http:///base/karma-tests/foobar.html');
-                    }
-                },
-            }, done);
+                    assert.equal(link.href, 'http:///base/karma-tests/foobar.html');
+                }
+            };
+
+            runWombatTest(config, done);
+        });
+
+        it('toString() should return the rewritten URL', function (done) {
+            config.testScript = function () {
+                if (domTests.areDOMPropertiesConfigurable()) {
+                    var link = document.getElementById('link');
+                    assert.equal(link.href, link.toString());
+                }
+            };
+            runWombatTest(config, done);
         });
     });
 

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -1397,6 +1397,9 @@ var wombat_internal = function($wbwindow) {
         }
 
         init_loc_override($wbwindow.HTMLAnchorElement.prototype, anchor_setter, anchor_getter);
+        $wbwindow.HTMLAnchorElement.prototype.toString = function () {
+            return this.href;
+        };
     }
 
 


### PR DESCRIPTION
The values returned by getting the 'href' and 'toString'
properties of an anchor element should be the same.

This inconsistency broke the URL polyfill in
https://github.com/inexorabletash/polyfill under Microsoft Edge

This was the underlying cause of the issue seen in https://github.com/hypothesis/via/issues/64