### PR TITLE
fix/tweak for cli --help

### DIFF
--- a/pywb/apps/cli.py
+++ b/pywb/apps/cli.py
@@ -29,7 +29,7 @@ def wayback(args=None):
 #=============================================================================
 class BaseCli(object):
     def __init__(self, args=None, default_port=8080, desc=''):
-        parser = ArgumentParser(desc)
+        parser = ArgumentParser(description=desc)
         parser.add_argument('-p', '--port', type=int, default=default_port)
         parser.add_argument('-t', '--threads', type=int, default=4)
         parser.add_argument('-s', '--server')


### PR DESCRIPTION
before:
```
$ wayback --help
usage: pywb Wayback Web Archive Replay [-h] [-p PORT] [-t THREADS] [-s SERVER] [-a] [-d DIRECTORY]

optional arguments:
  -h, --help            show this help message and exit
  -p PORT, --port PORT
  -t THREADS, --threads THREADS
  -s SERVER, --server SERVER
  -a, --autoindex
  -d DIRECTORY, --directory DIRECTORY
                        Specify root archive dir (default is current working directory)
```

after:
```
$ wayback --help
usage: wayback [-h] [-p PORT] [-t THREADS] [-s SERVER] [-a] [-d DIRECTORY]

pywb Wayback Web Archive Replay

optional arguments:
  -h, --help            show this help message and exit
  -p PORT, --port PORT
  -t THREADS, --threads THREADS
  -s SERVER, --server SERVER
  -a, --autoindex
  -d DIRECTORY, --directory DIRECTORY
                        Specify root archive dir (default is current working directory)
```