### PR TITLE
Improve handling of exceptions in wsgi_wrappers, fixes #219

### DIFF
--- a/pywb/framework/wsgi_wrappers.py
+++ b/pywb/framework/wsgi_wrappers.py
@@ -86,7 +86,19 @@ class WSGIApp(object):
             error_view = self.wb_router.error_view
 
         if hasattr(exc, 'status'):
-            status = exc.status()
+            if callable(exc.status):
+                status = exc.status()
+            else:
+                status = exc.status
+            # wsgi requires status
+            #  - to have at least 4 characters and
+            #  - to start with a number / integer
+            if type(status) == int:
+                status = '{} Exception {}'.format(status, type(exc).__name__)
+            elif type(status) == str and status[0].isdigit():
+                pass
+            else:
+                status = '500 Internal Server Error'
         else:
             status = '500 Internal Server Error'
 
@@ -96,7 +108,7 @@ class WSGIApp(object):
             err_url = None
 
         if len(exc.args):
-            err_msg = exc.args[0]
+            err_msg = str(exc.args[0])
 
         if print_trace:
             import traceback
@@ -125,7 +137,7 @@ class WSGIApp(object):
 
             #msg = msg.encode('utf-8', 'ignore')
             return WbResponse.text_response(msg,
-                                           status=status)
+                                            status=status)
 
 #=================================================================
 DEFAULT_CONFIG_FILE = 'config.yaml'

--- a/pywb/utils/test/test_loaders.py
+++ b/pywb/utils/test/test_loaders.py
@@ -166,7 +166,7 @@ def seek_read_full(seekable_reader, offset):
 def test_s3_read_1():
     pytest.importorskip('boto')
 
-    res = BlockLoader().load('s3://aws-publicdatasets/common-crawl/crawl-data/CC-MAIN-2015-11/segments/1424936462700.28/warc/CC-MAIN-20150226074102-00159-ip-10-28-5-156.ec2.internal.warc.gz',
+    res = BlockLoader().load('s3://commoncrawl/crawl-data/CC-MAIN-2015-11/segments/1424936462700.28/warc/CC-MAIN-20150226074102-00159-ip-10-28-5-156.ec2.internal.warc.gz',
                              offset=53235662,
                              length=2526)
 


### PR DESCRIPTION
- check whether exception status conforms to the format expected by wsgi `NNN message`
- try to convert status if not
- make sure err_msg is of type str