### PR TITLE
Rewrite Improvements

### DIFF
--- a/pywb/rewrite/default_rewriter.py
+++ b/pywb/rewrite/default_rewriter.py
@@ -79,6 +79,12 @@ class DefaultRewriter(BaseContentRewriter):
         'text/plain': 'plain',
     }
 
+    default_content_types = {
+        'html': 'text/html',
+        'css': 'text/css',
+        'js': 'text/javascript'
+    }
+
     def __init__(self, rules_file=None, replay_mod=''):
         rules_file = rules_file or 'pkg://pywb/rules.yaml'
         super(DefaultRewriter, self).__init__(rules_file, replay_mod)

--- a/pywb/rewrite/test/test_content_rewriter.py
+++ b/pywb/rewrite/test/test_content_rewriter.py
@@ -1,0 +1,109 @@
+from warcio.warcwriter import BufferWARCWriter, GzippingWrapper
+from warcio.statusandheaders import StatusAndHeaders
+
+from io import BytesIO
+
+from pywb.warcserver.index.cdxobject import CDXObject
+from pywb.utils.canonicalize import canonicalize
+
+from pywb.rewrite.wburl import WbUrl
+from pywb.rewrite.url_rewriter import UrlRewriter
+from pywb.rewrite.default_rewriter import DefaultRewriter
+
+import pytest
+
+
+@pytest.fixture(params=[{'Content-Type': 'text/html'},
+                        {'Content-Type': 'application/xhtml+xml'},
+                        {}],
+                ids=['html', 'xhtml', 'none'])
+def headers(request):
+    return request.param
+
+
+# ============================================================================
+class TestContentRewriter(object):
+    @classmethod
+    def setup_class(self):
+        self.content_rewriter = DefaultRewriter()
+
+    def _create_response_record(self, url, headers, payload):
+        writer = BufferWARCWriter()
+
+        payload = payload.encode('utf-8')
+
+        http_headers = StatusAndHeaders('200 OK', headers, protocol='HTTP/1.0')
+
+        return writer.create_warc_record(url, 'response',
+                                         payload=BytesIO(payload),
+                                         length=len(payload),
+                                         http_headers=http_headers)
+
+    def rewrite_record(self, headers, content, url='http://example.com/',
+                       ts='20170102030000000', prefix='http://localhost:8080/prefix/'):
+
+        record = self._create_response_record(url, headers, content)
+
+        wburl = WbUrl(ts + '/' + url)
+        print(wburl.mod)
+        url_rewriter = UrlRewriter(wburl, prefix)
+
+        cdx = CDXObject()
+        cdx['url'] = url
+        cdx['timestamp'] = ts
+        cdx['urlkey'] = canonicalize(url)
+
+        return self.content_rewriter(record, url_rewriter, None, cdx=cdx)
+
+    def test_rewrite_html(self, headers):
+        content = '<html><body><a href="http://example.com/"></a></body></html>'
+
+        headers, gen, is_rw = self.rewrite_record(headers, content)
+
+        assert ('Content-Type', 'text/html') in headers.headers
+
+        exp = '<html><body><a href="http://localhost:8080/prefix/20170102030000000/http://example.com/"></a></body></html>'
+        assert b''.join(gen).decode('utf-8') == exp
+
+    def test_rewrite_html_js_mod(self, headers):
+        content = '<html><body><a href="http://example.com/"></a></body></html>'
+
+        headers, gen, is_rw = self.rewrite_record(headers, content, ts='201701js_')
+
+        assert ('Content-Type', 'text/html') in headers.headers
+
+        exp = '<html><body><a href="http://localhost:8080/prefix/201701/http://example.com/"></a></body></html>'
+        assert b''.join(gen).decode('utf-8') == exp
+
+    def test_rewrite_js_mod(self, headers):
+        content = 'function() { location.href = "http://example.com/"; }'
+
+        headers, gen, is_rw = self.rewrite_record(headers, content, ts='201701js_')
+
+        assert ('Content-Type', 'text/javascript') in headers.headers
+
+        exp = 'function() { WB_wombat_location.href = "http://example.com/"; }'
+        assert b''.join(gen).decode('utf-8') == exp
+
+    def test_rewrite_cs_mod(self, headers):
+        content = '.foo { background: url(http://localhost:8080/prefix/201701cs_/http://example.com/) }'
+
+        headers, gen, is_rw = self.rewrite_record(headers, content, ts='201701cs_')
+
+        assert ('Content-Type', 'text/css') in headers.headers
+
+        exp = '.foo { background: url(http://localhost:8080/prefix/201701cs_/http://example.com/) }'
+
+        assert b''.join(gen).decode('utf-8') == exp
+
+    def test_binary_no_content_type(self):
+        headers = {}
+        content = '\x11\x12\x13\x14'
+        headers, gen, is_rw = self.rewrite_record(headers, content, ts='201701mp_')
+
+        assert 'Content-Type' not in headers.headers
+
+        assert is_rw == False
+
+
+

--- a/pywb/rewrite/test/test_header_rewriter.py
+++ b/pywb/rewrite/test/test_header_rewriter.py
@@ -44,7 +44,7 @@ class TestHeaderRewriter(object):
 HTTP/1.0 200 OK\r\n\
 X-Archive-Orig-Date: Fri, 03 Jan 2014 03:03:21 GMT\r\n\
 Content-Length: 5\r\n\
-Content-Type: text/html;charset=UTF-8\r\n\
+Content-Type: text/html; charset=utf-8\r\n\
 """
         rwinfo = self.do_rewrite('200 OK', headers)
         http_headers = PrefixHeaderRewriter(rwinfo)()

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -2124,15 +2124,15 @@ var _WBWombat = function($wbwindow, wbinfo) {
     }
 
     //============================================
-    function init_mo_from_proxy() {
-        var orig_observe = $wbwindow.MutationObserver.prototype.observe;
+    function override_func_first_arg_proxy_to_obj(prototype, method) {
+        var orig = prototype[method];
 
-        function observe_deproxy(target, options) {
-            target = proxy_to_obj(target);
-            return orig_observe.call(this, target, options);
+        function deproxy() {
+            arguments[0] = proxy_to_obj(arguments[0]);
+            orig.apply(this, arguments);
         }
 
-        $wbwindow.MutationObserver.prototype.observe = observe_deproxy;
+        prototype[method] = deproxy;
     }
 
     //============================================
@@ -2803,6 +2803,10 @@ var _WBWombat = function($wbwindow, wbinfo) {
             override_iframe_content_access("contentWindow");
             override_iframe_content_access("contentDocument");
 
+            // override funcs to convert first arg proxy->obj
+            override_func_first_arg_proxy_to_obj($wbwindow.MutationObserver.prototype, "observe");
+            override_func_first_arg_proxy_to_obj($wbwindow.Node.prototype, "compareDocumentPosition");
+
             override_frames_access($wbwindow);
 
             // setAttribute
@@ -2862,8 +2866,6 @@ var _WBWombat = function($wbwindow, wbinfo) {
         // add window and document obj proxies, if available
         init_window_obj_proxy($wbwindow);
         init_document_obj_proxy($wbwindow.document);
-
-        init_mo_from_proxy();
 
         // expose functions
         var obj = {}


### PR DESCRIPTION
- Better handling of missing Content-Type
- Ensure correct content-type is used, ensure xhtml served as text/html
- Client Side JS Obj Proxy: Node.computeDocumentPosition() converts proxy->obj
- Server Side (JS Obj Proxy): rewrite `= this` assignment to check for proxy
- New tests for content rewriter, js obj proxy rewriter regex replacements