### PR TITLE
Support CDX-Server API

### DIFF
--- a/pywb/apps/rewriterapp.py
+++ b/pywb/apps/rewriterapp.py
@@ -48,11 +48,11 @@ class UpstreamException(WbException):
 class RewriterApp(object):
     VIDEO_INFO_CONTENT_TYPE = 'application/vnd.youtube-dl_formats+json'
 
-    def __init__(self, framed_replay=False, jinja_env=None, config=None):
+    def __init__(self, framed_replay=False, jinja_env=None, config=None, paths=None):
         self.loader = ArcWarcRecordLoader()
 
         self.config = config or {}
-        self.paths = {}
+        self.paths = paths or {}
 
         self.framed_replay = framed_replay
 

--- a/pywb/warcserver/basewarcserver.py
+++ b/pywb/warcserver/basewarcserver.py
@@ -26,16 +26,20 @@ class BaseWarcServer(object):
 
         self.url_map.add(Rule('/', endpoint=list_routes))
 
-    def add_route(self, path, handler):
-        def direct_input_request(environ, mode=''):
+    def add_route(self, path, handler, path_param_name=''):
+        def direct_input_request(environ, mode='', path_param_value=''):
             params = self.get_query_dict(environ)
             params['mode'] = mode
+            if path_param_value:
+                params[path_param_name] = path_param_value
             params['_input_req'] = DirectWSGIInputRequest(environ)
             return handler(params)
 
-        def post_fullrequest(environ, mode=''):
+        def post_fullrequest(environ, mode='', path_param_value=''):
             params = self.get_query_dict(environ)
             params['mode'] = mode
+            if path_param_value:
+                params[path_param_name] = path_param_value
             params['_input_req'] = POSTInputRequest(environ)
             return handler(params)
 

--- a/tests/config_test_root_coll.yaml
+++ b/tests/config_test_root_coll.yaml
@@ -3,6 +3,6 @@ debug: true
 collections_root: _test_colls
 
 collections:
-    '$root': $live
+    '$root': '$live'
 
 

--- a/tests/test_cdx_server_app.py
+++ b/tests/test_cdx_server_app.py
@@ -24,7 +24,7 @@ class TestCDXApp(BaseTestClass):
 
     def query(self, url, is_error=False, **params):
         params['url'] = url
-        return self.testapp.get('/pywb-cdx?' + urlencode(params, doseq=1), expect_errors=is_error)
+        return self.testapp.get('/pywb/index?' + urlencode(params, doseq=1), expect_errors=is_error)
 
     def test_exact_url(self):
         """

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -428,15 +428,15 @@ class TestWbIntegration(BaseConfigTest):
         resp = self.testapp.get('/static/notfound.css', status = 404)
         assert resp.status_int == 404
 
-    def _test_cdx_server_filters(self):
-        resp = self.testapp.get('/pywb-cdx?url=http://www.iana.org/_css/2013.1/screen.css&filter=mime:warc/revisit&filter=filename:dupes.warc.gz')
-        self._assert_basic_text(resp)
+    def test_cdx_server_filters(self):
+        resp = self.testapp.get('/pywb/cdx?url=http://www.iana.org/_css/2013.1/screen.css&filter=mime:warc/revisit&filter=filename:dupes.warc.gz')
+        assert resp.content_type == 'text/x-cdxj'
         actual_len = len(resp.text.rstrip().split('\n'))
         assert actual_len == 1, actual_len
 
-    def _test_cdx_server_advanced(self):
+    def test_cdx_server_advanced(self):
         # combine collapsing, reversing and revisit resolving
-        resp = self.testapp.get('/pywb-cdx?url=http://www.iana.org/_css/2013.1/print.css&collapseTime=11&resolveRevisits=true&reverse=true')
+        resp = self.testapp.get('/pywb/cdx?url=http://www.iana.org/_css/2013.1/print.css&collapseTime=11&resolveRevisits=true&reverse=true')
 
         # convert back to CDXObject
         cdxs = list(map(CDXObject, resp.body.rstrip().split(b'\n')))

--- a/tests/test_root_coll.py
+++ b/tests/test_root_coll.py
@@ -37,3 +37,9 @@ class TestRootColl(BaseConfigTest):
         resp = self.testapp.get('/')
         assert 'Search' in resp.text
 
+    def test_root_cdx(self):
+        resp = self.testapp.get('/cdx?url=http://www.iana.org/&output=json&limit=1')
+        resp.content_type = 'application/json'
+        assert resp.json['is_live'] == 'true'
+        assert resp.json['url'] == 'http://www.iana.org/'
+        assert resp.json['source'] == '$root'


### PR DESCRIPTION
frontendapp/warcserver improvements:
- support '/cdx' endpoint for every collection, exposing standard cdx-server api
- remove '-cdx' endpoint in warcserver, redundant with index and frontend /cdx endpoint
- warcserver: simplify paths! support static paths (/A, /B) + dynamic paths (/<path>) on same endpoint