### PR TITLE
Index WARC-Identified-Payload-Type

### DIFF
--- a/pywb/indexer/archiveindexer.py
+++ b/pywb/indexer/archiveindexer.py
@@ -265,6 +265,9 @@ class DefaultRecordParser(object):
             entry.extract_mime(record.http_headers.
                                get_header('Content-Type'),
                                def_mime)
+            # detected mime from WARC-Identified-Payload-Type
+            entry['mime-detected'] = record.rec_headers.get_header(
+                                        'WARC-Identified-Payload-Type')
 
         # status -- only for response records (by convention):
         if record.rec_type == 'response' and not self.options.get('minimal'):


### PR DESCRIPTION
Extract WARC field [WARC-Identified-Payload-Type](https://github.com/iipc/warc-specifications/blob/gh-pages/specifications/warc-format/warc-1.1/index.md#warc-identified-payload-type)" and add it as field "mime-detected" to index entry, cf. [commoncrawl/nutch#3](/commoncrawl/nutch/issues/3).