### PR TITLE
client-side rewrite: web worker and document access improvements

### DIFF
--- a/pywb/static/ww_rw.js
+++ b/pywb/static/ww_rw.js
@@ -1,0 +1,37 @@
+// pywb mini rewriter for injection into web worker scripts
+
+function WBWombat(info) {
+
+    function rewrite_url(url) {
+        if (info.prefix) {
+            return info.prefix + url;
+        } else {
+            return url;
+        }
+    }
+
+    function init_ajax_rewrite() {
+        var orig = self.XMLHttpRequest.prototype.open;
+
+        function open_rewritten(method, url, async, user, password) {
+            url = rewrite_url(url);
+
+            // defaults to true
+            if (async != false) {
+                async = true;
+            }
+
+            result = orig.call(this, method, url, async, user, password);
+
+            if (url.indexOf("data:") != 0) {
+                this.setRequestHeader('X-Pywb-Requested-With', 'XMLHttpRequest');
+            }
+        }
+
+        self.XMLHttpRequest.prototype.open = open_rewritten;
+    }
+
+    init_ajax_rewrite();
+}
+
+

--- a/pywb/templates/head_insert.html
+++ b/pywb/templates/head_insert.html
@@ -13,7 +13,7 @@
   wbinfo.is_live = {{ is_live }};
   wbinfo.coll = "{{ coll }}";
   wbinfo.proxy_magic = "{{ env.pywb_proxy_magic }}";
-  wbinfo.static_prefix = "{{ host_prefix }}/{{ static_path }}";
+  wbinfo.static_prefix = "{{ host_prefix }}/{{ static_path }}/";
 
 {% if not wb_url.is_banner_only %}
   wbinfo.wombat_ts = "{{ wombat_ts }}";


### PR DESCRIPTION
- add 'ww_rw' for injecting into webworkers via importScript() added when loading web workers as blobs
- 'WB_wombat_location' override checks for defaultView more consistently if _WB_wombat_location
- custom overrides __WB_pmw, WB_wombat_frameElement just fail silently instead of raising exception on assignment