### PR TITLE
Fuzzy Rewrite Improvements

### DIFF
--- a/pywb/rewrite/content_rewriter.py
+++ b/pywb/rewrite/content_rewriter.py
@@ -74,9 +74,10 @@ class BaseContentRewriter(object):
         rw_class = self.get_rewriter(rw_type, rwinfo)
 
         mixin = rule.get('mixin')
+        mixin_params = rule.get('mixin_params', {})
         if mixin:
             mixin = load_py_name(mixin)
-            rw_class = type('custom_js_rewriter', (mixin, rw_class), {})
+            rw_class = type('custom_js_rewriter', (mixin, rw_class), mixin_params)
 
         return rw_type, rw_class
 
@@ -166,8 +167,13 @@ class BaseContentRewriter(object):
 
         url_rewriter.rewrite_opts['cdx'] = cdx
 
+        rule = self.get_rule(cdx)
+
+        force_type = rule.get('force_type')
+        if force_type:
+            rwinfo.text_type = force_type
+
         if rwinfo.should_rw_content():
-            rule = self.get_rule(cdx)
             content_rewriter = self.create_rewriter(rwinfo.text_type, rule, rwinfo, cdx, head_insert_func)
 
         gen = None

--- a/pywb/rewrite/content_rewriter.py
+++ b/pywb/rewrite/content_rewriter.py
@@ -55,6 +55,10 @@ class BaseContentRewriter(object):
             parse_rules_func = self.init_js_regex(regexs)
             rule['js_regex_func'] = parse_rules_func
 
+        mixin = rule.get('mixin')
+        if mixin:
+            rule['mixin'] = load_py_name(mixin)
+
         return rule
 
     def get_rule(self, cdx):
@@ -74,9 +78,8 @@ class BaseContentRewriter(object):
         rw_class = self.get_rewriter(rw_type, rwinfo)
 
         mixin = rule.get('mixin')
-        mixin_params = rule.get('mixin_params', {})
         if mixin:
-            mixin = load_py_name(mixin)
+            mixin_params = rule.get('mixin_params', {})
             rw_class = type('custom_js_rewriter', (mixin, rw_class), mixin_params)
 
         return rw_type, rw_class
@@ -250,10 +253,8 @@ class StreamingRewriter(object):
         self.url_rewriter = url_rewriter
         self.align_to_line = align_to_line
         self.first_buff = first_buff
-        self.rwinfo = None
 
     def __call__(self, rwinfo):
-        self.rwinfo = rwinfo
         return self.rewrite_text_stream_to_gen(rwinfo.content_stream)
 
     def rewrite(self, string):

--- a/pywb/rewrite/regex_rewriters.py
+++ b/pywb/rewrite/regex_rewriters.py
@@ -12,11 +12,11 @@ class RegexRewriter(StreamingRewriter):
 
     @staticmethod
     def format(template):
-        return lambda string, _: template.format(string)
+        return lambda string: template.format(string)
 
     @staticmethod
     def fixed(string):
-        return lambda _, _2: string
+        return lambda _: string
 
     @staticmethod
     def remove_https(string):
@@ -24,11 +24,11 @@ class RegexRewriter(StreamingRewriter):
 
     @staticmethod
     def add_prefix(prefix):
-        return lambda string, _: prefix + string
+        return lambda string: prefix + string
 
     @staticmethod
     def archival_rewrite(rewriter):
-        return lambda string, _: rewriter.rewrite(string)
+        return lambda string: rewriter.rewrite(string)
 
 
     HTTPX_MATCH_STR = r'https?:\\?/\\?/[A-Za-z0-9:_@.-]+'
@@ -75,7 +75,7 @@ class RegexRewriter(StreamingRewriter):
             # if not hasattr(op, '__call__'):
             #    op = RegexRewriter.DEFAULT_OP(op)
 
-            result = op(m.group(i), self.url_rewriter)
+            result = op(m.group(i))
             final_str = result
 
             # if extracting partial match
@@ -176,7 +176,7 @@ if (!self.__WB_pmw) {{ self.__WB_pmw = function(obj) {{ return obj; }} }}\n\
 
     @classmethod
     def replace_str(cls, replacer):
-        return lambda x, _: x.replace('this', replacer)
+        return lambda x: x.replace('this', replacer)
 
     def __init__(self, rewriter, rules=[]):
         #func_rw = 'Function("return {0}")'.format(self.THIS_RW)
@@ -256,7 +256,9 @@ class JSWombatProxyRewriter(JSWombatProxyRewriterMixin, RegexRewriter):
 class JSReplaceFuzzy(object):
     def __init__(self, *args, **kwargs):
         super(JSReplaceFuzzy, self).__init__(*args, **kwargs)
-        self.rx = re.compile('"ssid":([\d]+)')
+        assert(self.rx)
+        if isinstance(self.rx, str):
+            self.rx = re.compile(self.rx)
 
     def rewrite(self, string):
         string = super(JSReplaceFuzzy, self).rewrite(string)
@@ -267,12 +269,9 @@ class JSReplaceFuzzy(object):
 
             exp_m = self.rx.search(expected)
             act_m = self.rx.search(actual)
-            print('ACT', act_m and act_m.group(1))
-            print('EXP', exp_m and exp_m.group(1))
             if exp_m and act_m:
                 result = string.replace(exp_m.group(1), act_m.group(1))
                 if result != string:
-                    print(result)
                     string = result
 
         return string

--- a/pywb/rewrite/regex_rewriters.py
+++ b/pywb/rewrite/regex_rewriters.py
@@ -254,11 +254,12 @@ class JSWombatProxyRewriter(JSWombatProxyRewriterMixin, RegexRewriter):
 
 # =================================================================
 class JSReplaceFuzzy(object):
+    rx_obj = None
+
     def __init__(self, *args, **kwargs):
         super(JSReplaceFuzzy, self).__init__(*args, **kwargs)
-        assert(self.rx)
-        if isinstance(self.rx, str):
-            self.rx = re.compile(self.rx)
+        if not self.rx_obj:
+            self.rx_obj = re.compile(self.rx)
 
     def rewrite(self, string):
         string = super(JSReplaceFuzzy, self).rewrite(string)
@@ -267,8 +268,9 @@ class JSReplaceFuzzy(object):
             expected = unquote(cdx['url'])
             actual = unquote(self.url_rewriter.wburl.url)
 
-            exp_m = self.rx.search(expected)
-            act_m = self.rx.search(actual)
+            exp_m = self.rx_obj.search(expected)
+            act_m = self.rx_obj.search(actual)
+
             if exp_m and act_m:
                 result = string.replace(exp_m.group(1), act_m.group(1))
                 if result != string:

--- a/pywb/rewrite/rewrite_dash.py
+++ b/pywb/rewrite/rewrite_dash.py
@@ -58,7 +58,7 @@ class RewriteDASH(BufferedRewriter):
 
 
 # ============================================================================
-def rewrite_fb_dash(string, url_rewriter):
+def rewrite_fb_dash(string):
     DASH_SPLIT = r'\n",dash_prefetched_representation_ids:'
     inx = string.find(DASH_SPLIT)
     if inx < 0:
@@ -76,14 +76,4 @@ def rewrite_fb_dash(string, url_rewriter):
     string += DASH_SPLIT
     string += json.dumps(best_ids)
     return string
-
-
-# ============================================================================
-def rewrite_photo(string, url_rewriter):
-    from urllib.parse import unquote
-    import re
-    url = url_rewriter.wburl.url
-    ssid = re.search('"ssid":([\d]+)', unquote(url)).group(1)
-    print('SSID', ssid)
-    return ssid
 

--- a/pywb/rewrite/rewrite_dash.py
+++ b/pywb/rewrite/rewrite_dash.py
@@ -58,7 +58,7 @@ class RewriteDASH(BufferedRewriter):
 
 
 # ============================================================================
-def rewrite_fb_dash(string):
+def rewrite_fb_dash(string, url_rewriter):
     DASH_SPLIT = r'\n",dash_prefetched_representation_ids:'
     inx = string.find(DASH_SPLIT)
     if inx < 0:
@@ -76,4 +76,14 @@ def rewrite_fb_dash(string):
     string += DASH_SPLIT
     string += json.dumps(best_ids)
     return string
+
+
+# ============================================================================
+def rewrite_photo(string, url_rewriter):
+    from urllib.parse import unquote
+    import re
+    url = url_rewriter.wburl.url
+    ssid = re.search('"ssid":([\d]+)', unquote(url)).group(1)
+    print('SSID', ssid)
+    return ssid
 

--- a/pywb/rules.yaml
+++ b/pywb/rules.yaml
@@ -87,15 +87,6 @@ rules:
           - 'parent_comment_ids[0]'
           - lsd
 
-    #- url_prefix: 'com,facebook)/ajax/typeahead/'
-
-    #  fuzzy_lookup:
-    #    - 'filter[0]'
-
-    #- url_prefix: 'com,facebook)/typeahead/'
-
-    #  fuzzy_lookup: '([?&][^_]\w+=[^&]+)+'
-
     - url_prefix: 'com,facebook)/ajax/ufi/'
 
       fuzzy_lookup:
@@ -127,14 +118,8 @@ rules:
     - url_prefix: 'com,facebook)/api/graphqlbatch'
 
       fuzzy_lookup:
-        #match: '((?:q[\d]")|(?:queryfragment[^:]+))'
-        match: '"q[\d]":'
+        match: '("q[\d]+":|after:\\"[^"]+)'
         find_all: true
-
-    - url_prefix: 'com,facebook)/sem_campaigns2/'
-
-      #fuzzy_lookup: '([?&][^_]\w+=[^&]+)+'
-      fuzzy_lookup: '()'
 
     - url_prefix: 'com,facebook)/'
 

--- a/pywb/rules.yaml
+++ b/pywb/rules.yaml
@@ -68,24 +68,33 @@ rules:
 
       rewrite:
         mixin: 'pywb.rewrite.regex_rewriters:JSReplaceFuzzy'
+        mixin_params:
+            rx: '"ssid":([\d]+)'
+
+        force_type: 'json'
         
       fuzzy_lookup: 'com,facebook\)/.*[?&]data=(.*?(?:[&]|(?:query_type|fbid)[^,]+))'
-        #js_regexs:
-        #  - match: '1503423881163'
-        #    group: 0
-        #    function: 'pywb.rewrite.rewrite_dash:rewrite_photo'
 
     - url_prefix: 'com,facebook)/ajax/pagelet/generic.php/'
 
       #fuzzy_lookup: 'com,facebook\)/.*[?&]data=(.*?(?:[&]|query_type[^,]+))'
       fuzzy_lookup: 'com,facebook\)/.*[?&]data=(.*?(?:[&]|(?:query_type|fbid)[^,]+))'
 
-    - url_prefix: 'com,facebook)/ajax/ufi/replay_fetch'
+    - url_prefix: 'com,facebook)/ajax/ufi/reply_fetch'
 
       fuzzy_lookup:
           - 'ft_ent_identifier'
           - 'parent_comment_ids[0]'
           - lsd
+
+    #- url_prefix: 'com,facebook)/ajax/typeahead/'
+
+    #  fuzzy_lookup:
+    #    - 'filter[0]'
+
+    #- url_prefix: 'com,facebook)/typeahead/'
+
+    #  fuzzy_lookup: '([?&][^_]\w+=[^&]+)+'
 
     - url_prefix: 'com,facebook)/ajax/ufi/'
 
@@ -116,6 +125,9 @@ rules:
       fuzzy_lookup: '([?&][^_]\w+=[^&]+)+'
 
     - url_prefix: 'com,facebook)/'
+
+      fuzzy_lookup: '()'
+
       rewrite:
         js_regexs:
             - match: 'Bootloader\.configurePage.*?;'

--- a/pywb/rules.yaml
+++ b/pywb/rules.yaml
@@ -124,9 +124,22 @@ rules:
 
       fuzzy_lookup: '([?&][^_]\w+=[^&]+)+'
 
+    - url_prefix: 'com,facebook)/api/graphqlbatch'
+
+      fuzzy_lookup:
+        #match: '((?:q[\d]")|(?:queryfragment[^:]+))'
+        match: '"q[\d]":'
+        find_all: true
+
+    - url_prefix: 'com,facebook)/sem_campaigns2/'
+
+      #fuzzy_lookup: '([?&][^_]\w+=[^&]+)+'
+      fuzzy_lookup: '()'
+
     - url_prefix: 'com,facebook)/'
 
-      fuzzy_lookup: '()'
+      fuzzy_lookup: '([?&][^_]\w+=[^&]+)+'
+      #fuzzy_lookup: '()'
 
       rewrite:
         js_regexs:

--- a/pywb/rules.yaml
+++ b/pywb/rules.yaml
@@ -64,10 +64,28 @@ rules:
 
     # facebook rules
     #=================================================================
+    - url_prefix: 'com,facebook)/ajax/pagelet/generic.php/photoviewerinitpagelet'
+
+      rewrite:
+        mixin: 'pywb.rewrite.regex_rewriters:JSReplaceFuzzy'
+        
+      fuzzy_lookup: 'com,facebook\)/.*[?&]data=(.*?(?:[&]|(?:query_type|fbid)[^,]+))'
+        #js_regexs:
+        #  - match: '1503423881163'
+        #    group: 0
+        #    function: 'pywb.rewrite.rewrite_dash:rewrite_photo'
+
     - url_prefix: 'com,facebook)/ajax/pagelet/generic.php/'
 
       #fuzzy_lookup: 'com,facebook\)/.*[?&]data=(.*?(?:[&]|query_type[^,]+))'
       fuzzy_lookup: 'com,facebook\)/.*[?&]data=(.*?(?:[&]|(?:query_type|fbid)[^,]+))'
+
+    - url_prefix: 'com,facebook)/ajax/ufi/replay_fetch'
+
+      fuzzy_lookup:
+          - 'ft_ent_identifier'
+          - 'parent_comment_ids[0]'
+          - lsd
 
     - url_prefix: 'com,facebook)/ajax/ufi/'
 

--- a/pywb/rules.yaml
+++ b/pywb/rules.yaml
@@ -80,12 +80,21 @@ rules:
       #fuzzy_lookup: 'com,facebook\)/.*[?&]data=(.*?(?:[&]|query_type[^,]+))'
       fuzzy_lookup: 'com,facebook\)/.*[?&]data=(.*?(?:[&]|(?:query_type|fbid)[^,]+))'
 
-    - url_prefix: 'com,facebook)/ajax/ufi/reply_fetch'
+    - url_prefix: 'com,facebook)/ajax/ufi/reply_fetch.php'
 
       fuzzy_lookup:
           - 'ft_ent_identifier'
           - 'parent_comment_ids[0]'
           - lsd
+
+    - url_prefix: 'com,facebook)/ajax/ufi/comment_fetch.php'
+
+      fuzzy_lookup:
+          - 'source'
+          - 'offset'
+          - 'length'
+          - 'ft_ent_identifier'
+          - 'feed_context'
 
     - url_prefix: 'com,facebook)/ajax/ufi/'
 

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -2452,8 +2452,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
         }
 
         function get_cookie() {
-            var res = orig_get_cookie.call(proxy_to_obj(this));
-            return res;
+            return orig_get_cookie.call(proxy_to_obj(this));
         }
 
         def_prop($wbwindow.document, "cookie", set_cookie, get_cookie);

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -873,7 +873,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
             init_opts = init_opts || {};
             init_opts["credentials"] = "include";
 
-            return orig_fetch.call(this, input, init_opts);
+            return orig_fetch.call(proxy_to_obj(this), input, init_opts);
         }
     }
 
@@ -2411,7 +2411,8 @@ var _WBWombat = function($wbwindow, wbinfo) {
         }
 
         function get_cookie() {
-            return orig_get_cookie.call(proxy_to_obj(this));
+            var res = orig_get_cookie.call(proxy_to_obj(this));
+            return res;
         }
 
         def_prop($wbwindow.document, "cookie", set_cookie, get_cookie);
@@ -2767,7 +2768,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
     //============================================
     function proxy_to_obj(source) {
         try {
-            return source.__WBProxyRealObj__ || source;
+            return (source && source.__WBProxyRealObj__) || source;
         } catch (e) {
             return source;
         }

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -918,40 +918,6 @@ var _WBWombat = function($wbwindow, wbinfo) {
         $wbwindow.Request.prototype = orig_request.prototype;
     }
 
-
-    //============================================
-    function init_request_override()
-    {
-        var orig_request = $wbwindow.Request;
-
-        if (!orig_request) {
-            return;
-        }
-
-        $wbwindow.Request = (function (Request) {
-            return function(input, init_opts) {
-                if (typeof(input) === "string") {
-                    input = rewrite_url(input);
-                } else if (typeof(input) === "object" && input.url) {
-                    var new_url = rewrite_url(input.url);
-
-                    if (new_url != input.url) {
-                    //    input = new Request(new_url, input);
-                        input.url = new_url;
-                    }
-                }
-
-                init_opts = init_opts || {};
-                init_opts["credentials"] = "include";
-
-                return new Request(input, init_opts);
-            }
-
-        })($wbwindow.Request);
-
-        $wbwindow.Request.prototype = orig_request.prototype;
-    }
-
     //============================================
     function override_prop_extract(proto, prop, cond) {
         var orig_getter = get_orig_getter(proto, prop);

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -279,7 +279,10 @@ var _WBWombat = function($wbwindow, wbinfo) {
                     } else {
                         url = "";
                     }
-                    url += "/" + path;
+                    if (path && path[0] != "/") {
+                        url += "/";
+                    }
+                    url += path;
                 }
 
                 return url;
@@ -513,6 +516,10 @@ var _WBWombat = function($wbwindow, wbinfo) {
             function setter(value) {
                 if (this._no_rewrite) {
                     orig_setter.call(this, prop, value);
+                    return;
+                }
+
+                if (this["_" + prop] == value) {
                     return;
                 }
 
@@ -875,6 +882,40 @@ var _WBWombat = function($wbwindow, wbinfo) {
 
             return orig_fetch.call(proxy_to_obj(this), input, init_opts);
         }
+    }
+
+
+    //============================================
+    function init_request_override()
+    {
+        var orig_request = $wbwindow.Request;
+
+        if (!orig_request) {
+            return;
+        }
+
+        $wbwindow.Request = (function (Request) {
+            return function(input, init_opts) {
+                if (typeof(input) === "string") {
+                    input = rewrite_url(input);
+                } else if (typeof(input) === "object" && input.url) {
+                    var new_url = rewrite_url(input.url);
+
+                    if (new_url != input.url) {
+                    //    input = new Request(new_url, input);
+                        input.url = new_url;
+                    }
+                }
+
+                init_opts = init_opts || {};
+                init_opts["credentials"] = "include";
+
+                return new Request(input, init_opts);
+            }
+
+        })($wbwindow.Request);
+
+        $wbwindow.Request.prototype = orig_request.prototype;
     }
 
     //============================================
@@ -2998,6 +3039,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
 
             // Fetch
             init_fetch_rewrite();
+            init_request_override();
 
             // Worker override (experimental)
             init_web_worker_override();

--- a/pywb/utils/canonicalize.py
+++ b/pywb/utils/canonicalize.py
@@ -108,6 +108,16 @@ def calc_search_range(url, match_type, surt_ordered=True, url_canon=None):
     >>> calc_search_range('http://example.com/path/file.html', 'prefix')
     ('com,example)/path/file.html', 'com,example)/path/file.htmm')
 
+    # slash and ?
+    >>> calc_search_range('http://example.com/path/', 'prefix')
+    ('com,example)/path/', 'com,example)/path0')
+
+    >>> calc_search_range('http://example.com/path?', 'prefix')
+    ('com,example)/path?', 'com,example)/path@')
+
+    >>> calc_search_range('http://example.com/path/?', 'prefix')
+    ('com,example)/path?', 'com,example)/path@')
+
     >>> calc_search_range('http://example.com/path/file.html', 'host')
     ('com,example)/', 'com,example*')
 

--- a/pywb/utils/canonicalize.py
+++ b/pywb/utils/canonicalize.py
@@ -158,6 +158,9 @@ def calc_search_range(url, match_type, surt_ordered=True, url_canon=None):
         if url.endswith('/') and not start_key.endswith('/'):
             start_key += '/'
 
+        if url.endswith('?') and not start_key.endswith('?'):
+            start_key += '?'
+
         end_key = inc_last_char(start_key)
 
     elif match_type == 'host':

--- a/pywb/utils/loaders.py
+++ b/pywb/utils/loaders.py
@@ -30,6 +30,15 @@ except ImportError:  #pragma: no cover
     s3_avail = False
 
 
+# =================================================================
+def load_py_name(string):
+    import importlib
+
+    string = string.split(':', 1)
+    mod = importlib.import_module(string[0])
+    return getattr(mod, string[1])
+
+
 #=================================================================
 def is_http(filename):
     return filename.startswith(('http://', 'https://'))

--- a/pywb/warcserver/index/fuzzymatcher.py
+++ b/pywb/warcserver/index/fuzzymatcher.py
@@ -95,10 +95,17 @@ class FuzzyMatcher(object):
 
         url = params['url']
 
+        # support matching w/o query if no additional filters
+        # don't include trailing '?' if no filters and replace_after '?'
+        no_filters = (filters == {'urlkey:'}) and (matched_rule.replace_after == '?')
+
         inx = url.find(matched_rule.replace_after)
         if inx > 0:
-            url = url[:inx + len(matched_rule.replace_after)]
-        else:
+            length = inx + len(matched_rule.replace_after)
+            if no_filters:
+                length -= 1
+            url = url[:length]
+        elif not no_filters:
             url += matched_rule.replace_after[0]
 
         if matched_rule.match_type == 'domain':

--- a/pywb/warcserver/index/fuzzymatcher.py
+++ b/pywb/warcserver/index/fuzzymatcher.py
@@ -98,7 +98,7 @@ class FuzzyMatcher(object):
         fuzzy_params = {'url': url,
                         'matchType': matched_rule.match_type,
                         'filter': filters,
-                        'is_fuzzy': True}
+                        'is_fuzzy': 'true'}
 
         for key in iterkeys(params):
             if key not in self.FUZZY_SKIP_PARAMS:
@@ -157,7 +157,7 @@ class FuzzyMatcher(object):
 
         for cdx in new_iter:
             if is_custom or self.match_general_fuzzy_query(url, urlkey, cdx, rx_cache):
-                cdx['is_fuzzy'] = True
+                cdx['is_fuzzy'] = 'true'
                 yield cdx
 
     def match_general_fuzzy_query(self, url, urlkey, cdx, rx_cache):

--- a/pywb/warcserver/index/fuzzymatcher.py
+++ b/pywb/warcserver/index/fuzzymatcher.py
@@ -90,6 +90,10 @@ class FuzzyMatcher(object):
         inx = url.find(matched_rule.replace_after)
         if inx > 0:
             url = url[:inx + len(matched_rule.replace_after)]
+        else:
+            pass
+            #url += matched_rule.replace_after[0]
+            #print('*********************** PREFIX', url)
 
         if matched_rule.match_type == 'domain':
             host = urlsplit(url).netloc
@@ -98,7 +102,7 @@ class FuzzyMatcher(object):
         fuzzy_params = {'url': url,
                         'matchType': matched_rule.match_type,
                         'filter': filters,
-                        'is_fuzzy': 'true'}
+                        'is_fuzzy': '1'}
 
         for key in iterkeys(params):
             if key not in self.FUZZY_SKIP_PARAMS:
@@ -157,7 +161,7 @@ class FuzzyMatcher(object):
 
         for cdx in new_iter:
             if is_custom or self.match_general_fuzzy_query(url, urlkey, cdx, rx_cache):
-                cdx['is_fuzzy'] = 'true'
+                cdx['is_fuzzy'] = '1'
                 yield cdx
 
     def match_general_fuzzy_query(self, url, urlkey, cdx, rx_cache):

--- a/pywb/warcserver/index/test/test_fuzzymatcher.py
+++ b/pywb/warcserver/index/test/test_fuzzymatcher.py
@@ -38,7 +38,7 @@ class TestFuzzy(object):
     def get_expected(self, url, mime='text/html', filters=None):
         filters = filters or {'urlkey:'}
         exp = [{'filter': filters,
-               'is_fuzzy': True,
+               'is_fuzzy': '1',
                'urlkey': canonicalize(url),
                'source': 'source',
                'source-coll': 'source',


### PR DESCRIPTION
- Fuzzy match work for FB
- Support for 'find_all' fuzzy match, using regex `findall` call
- Keep trailing '?' on prefix queries