### PR TITLE
Rules Work (vimeo) and live_only flag

### DIFF
--- a/pywb/apps/cli.py
+++ b/pywb/apps/cli.py
@@ -35,6 +35,7 @@ class BaseCli(object):
         parser.add_argument('--profile', action='store_true')
 
         parser.add_argument('--live', action='store_true', help='Add live-web handler at /live')
+        parser.add_argument('--record', action='store_true')
 
         parser.add_argument('--proxy', help='Enable HTTP/S Proxy on specified collection')
         parser.add_argument('--proxy-record', action='store_true', help='Enable Proxy Recording into specified collection')
@@ -70,6 +71,9 @@ class BaseCli(object):
 
         if self.r.debug:
             self.extra_config['debug'] = True
+
+        if self.r.record:
+            self.extra_config['recorder'] = 'live'
 
     def run(self):
         self.run_gevent()

--- a/pywb/rewrite/content_rewriter.py
+++ b/pywb/rewrite/content_rewriter.py
@@ -70,6 +70,15 @@ class BaseContentRewriter(object):
 
         return {}
 
+    def has_custom_rules(self, rule, cdx):
+        if 'js_regex_func' not in rule:
+            return False
+
+        if rule.get('live_only') and not cdx.get('is_live'):
+            return False
+
+        return True
+
     def get_rw_class(self, rule, text_type, rwinfo):
         if text_type == 'json' and 'js_regex_func' in rule:
             text_type = 'js-proxy'
@@ -92,7 +101,7 @@ class BaseContentRewriter(object):
 
         if rw_type in ('js', 'js-proxy'):
             extra_rules = []
-            if 'js_regex_func' in rule:
+            if self.has_custom_rules(rule, cdx):
                 extra_rules = rule['js_regex_func'](rwinfo.url_rewriter)
 
             # if js-proxy and no rules, default to none

--- a/pywb/rewrite/content_rewriter.py
+++ b/pywb/rewrite/content_rewriter.py
@@ -71,6 +71,9 @@ class BaseContentRewriter(object):
         return {}
 
     def get_rw_class(self, rule, text_type, rwinfo):
+        if text_type == 'json' and 'js_regex_func' in rule:
+            text_type = 'js-proxy'
+
         if text_type == 'js' and not rwinfo.is_url_rw():
             text_type = 'js-proxy'
 

--- a/pywb/rules.yaml
+++ b/pywb/rules.yaml
@@ -268,6 +268,7 @@ rules:
           regex: 'com,vimeo.player\)/video/[\d]+/config?.*'
 
       rewrite:
+        live_only: true
         js_regexs:
             - match: '"dash":'
               replace: '"__dash":'

--- a/pywb/rules.yaml
+++ b/pywb/rules.yaml
@@ -261,6 +261,20 @@ rules:
       # only use non query part of url, ignore query
       fuzzy_lookup: '()'
 
+    - url_prefix: 'com,vimeo,player)/video/'
+
+      fuzzy_lookup:
+        match:
+          regex: 'com,vimeo.player\)/video/[\d]+/config?.*'
+
+      rewrite:
+        js_regexs:
+            - match: '"dash":'
+              replace: '"__dash":'
+
+            - match: '"hls":'
+              replace: '"__hls":'
+
     - url_prefix: 'com,vimeocdn,'
 
       fuzzy_lookup: '()'
@@ -279,7 +293,9 @@ rules:
           - videoFileId
           - signature
 
+
     # vine
+    #=================================================================
     - url_prefix: 'co,vine,cdn,'
 
       fuzzy_lookup:


### PR DESCRIPTION
- new rules to disable dash/hls for vimeo
- apply 'js_regexs' on 'json' content, using 'js-proxy' rewriter