### PR TITLE
range request fixes:

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,5 +7,5 @@ dist/
 **/*.egg-info
 **/__pycache__
 **/*.pyc
-
+collections/
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -189,42 +189,6 @@ class TestWbIntegration(BaseConfigTest):
         # original unrewritten url present
         assert '"http://www.iana.org/domains/example"' in resp.text
 
-    def _test_replay_range_cache_content(self):
-        headers = [('Range', 'bytes=0-200')]
-        resp = self.testapp.get('/pywb/20140127171250id_/http://example.com', headers=headers)
-
-        assert resp.status_int == 206
-        assert resp.headers['Accept-Ranges'] == 'bytes'
-        assert resp.headers['Content-Range'] == 'bytes 0-200/1270', resp.headers['Content-Range']
-        assert resp.content_length == 201, resp.content_length
-
-        assert 'wombat.js' not in resp.text
-
-    def _test_replay_content_ignore_range(self):
-        headers = [('Range', 'bytes=0-200')]
-        resp = self.testapp.get('/pywb-norange/20140127171251id_/http://example.com', headers=headers)
-
-        # range request ignored
-        assert resp.status_int == 200
-
-        # full response
-        assert resp.content_length == 1270, resp.content_length
-
-        # identity, no header insertion
-        assert 'wombat.js' not in resp.text
-
-    def _test_replay_range_cache_content_bound_end(self):
-        headers = [('Range', 'bytes=10-10000')]
-        resp = self.testapp.get('/pywb/20140127171251id_/http://example.com', headers=headers)
-
-        assert resp.status_int == 206
-        assert resp.headers['Accept-Ranges'] == 'bytes'
-        assert resp.headers['Content-Range'] == 'bytes 10-1269/1270', resp.headers['Content-Range']
-        assert resp.content_length == 1260, resp.content_length
-        assert len(resp.text) == resp.content_length
-
-        assert 'wombat.js' not in resp.text
-
     def _test_replay_redir_no_cache(self):
         headers = [('Range', 'bytes=10-10000')]
         # Range ignored

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -1,0 +1,78 @@
+from .base_config_test import BaseConfigTest, fmod
+from pywb.warcserver.warcserver import BaseWarcServer
+from mock import patch
+
+orig_call = BaseWarcServer.__call__
+
+# ============================================================================
+def mock_call(self, environ, start_response):
+    TestReplayRange.recorder_skip = environ.get('HTTP_RECORDER_SKIP')
+    return orig_call(self, environ, start_response)
+
+
+# ============================================================================
+@patch('pywb.warcserver.basewarcserver.BaseWarcServer.__call__', mock_call)
+class TestReplayRange(BaseConfigTest):
+    recorder_skip = None
+    recorder_range = None
+
+    @classmethod
+    def setup_class(cls):
+        super(TestReplayRange, cls).setup_class('config_test.yaml')
+
+    def test_replay_range_start_end(self, fmod):
+        headers = [('Range', 'bytes=0-200')]
+        resp = self.get('/pywb/20140127171250{0}/http://example.com/', fmod, headers=headers)
+
+        assert resp.status_int == 206
+        assert resp.headers['Accept-Ranges'] == 'bytes'
+        assert resp.headers['Content-Range'] == 'bytes 0-200/1270', resp.headers['Content-Range']
+        assert resp.content_length == 201, resp.content_length
+
+        assert self.recorder_skip == None
+
+        assert 'wombat.js' not in resp.text
+
+    def test_replay_range_start_end_2(self, fmod):
+        headers = [('Range', 'bytes=10-200')]
+        resp = self.get('/pywb/20140127171250{0}/http://example.com/', fmod, headers=headers)
+
+        assert resp.status_int == 206
+        assert resp.headers['Accept-Ranges'] == 'bytes'
+        assert resp.headers['Content-Range'] == 'bytes 10-200/1270', resp.headers['Content-Range']
+        assert resp.content_length == 191, resp.content_length
+
+        assert self.recorder_skip == '1'
+
+        assert 'wombat.js' not in resp.text
+
+    def test_replay_range_start_only(self, fmod):
+        headers = [('Range', 'bytes=0-')]
+        resp = self.get('/pywb/20140127171250{0}/http://example.com/', fmod, headers=headers)
+
+        assert resp.status_int == 206
+        assert resp.headers['Accept-Ranges'] == 'bytes'
+        assert resp.headers['Content-Range'] == 'bytes 0-1269/1270', resp.headers['Content-Range']
+        assert resp.content_length == 1270, resp.content_length
+
+        assert self.recorder_skip == None
+
+        assert 'wombat.js' not in resp.text
+
+    def test_error_range_out_of_bounds_1(self, fmod):
+        headers = [('Range', 'bytes=10-2000')]
+        resp = self.get('/pywb/20140127171251{0}/http://example.com/', fmod, headers=headers, status=416)
+
+        assert resp.status_int == 416
+
+        assert self.recorder_skip == '1'
+
+
+    def test_error_range_out_of_bounds_2(self, fmod):
+        headers = [('Range', 'bytes=2000-10')]
+        resp = self.get('/pywb/20140127171251{0}/http://example.com/', fmod, headers=headers, status=416)
+
+        assert resp.status_int == 416
+
+        assert self.recorder_skip == '1'
+


### PR DESCRIPTION
- fully support range requests on frontend, if range request reaches pywb
- add OffsetLimitReader() to skip offset and limit read
- disbale rewriting for range requests
- serve 416 if range outside of content-length
- tests: add tests for range request handling
dockerignore: add collections/