### PR TITLE
add - pass in colls_dir instead of hardcoding

### DIFF
--- a/pywb/apps/frontendapp.py
+++ b/pywb/apps/frontendapp.py
@@ -144,7 +144,11 @@ class FrontEndApp(object):
             return
 
         from pywb.manager.autoindex import AutoIndexer
-        indexer = AutoIndexer(interval=int(auto_interval))
+
+        colls_dir = self.warcserver.root_dir if self.warcserver.root_dir else None
+
+        indexer = AutoIndexer(colls_dir=colls_dir, interval=int(auto_interval))
+
         if not os.path.isdir(indexer.root_path):
             msg = 'No managed directory "{0}" for auto-indexing'
             logging.error(msg.format(indexer.root_path))

--- a/pywb/manager/autoindex.py
+++ b/pywb/manager/autoindex.py
@@ -12,8 +12,8 @@ class AutoIndexer(object):
     EXT_RX = re.compile('.*\.w?arc(\.gz)?$')
     AUTO_INDEX_FILE = 'autoindex.cdxj'
 
-    def __init__(self, interval=30, keep_running=True):
-        self.manager = CollectionsManager('', must_exist=False)
+    def __init__(self, colls_dir=None, interval=30, keep_running=True):
+        self.manager = CollectionsManager('', colls_dir=colls_dir, must_exist=False)
 
         self.root_path = self.manager.colls_dir
 


### PR DESCRIPTION
I tried changing the `collections_root` directory and ran into a problem with the AutoIndexer — it looks like you might be hard coding to the `collections: collections`. Passing in `colls_dir` from FrontEndApp to AutoIndexer instead.