### PR TITLE
Separate rewritten srcset image urls; handle urls with commas

### DIFF
--- a/pywb/rewrite/html_rewriter.py
+++ b/pywb/rewrite/html_rewriter.py
@@ -238,8 +238,8 @@ class HTMLRewriterMixin(StreamingRewriter):
         if not value:
             return ''
 
-        values = value.split(',')
-        values = [self._rewrite_url(v.strip()) for v in values]
+        values = (url.strip() for url in re.split("\s*(\S*\s+[\d\.]+[wx]),|(?:\s*,\s+)", value) if url)
+        values = [self._rewrite_url(v) for v in values]
         return ', '.join(values)
 
     def _rewrite_css(self, css_content):

--- a/pywb/rewrite/html_rewriter.py
+++ b/pywb/rewrite/html_rewriter.py
@@ -240,7 +240,7 @@ class HTMLRewriterMixin(StreamingRewriter):
 
         values = value.split(',')
         values = [self._rewrite_url(v.strip()) for v in values]
-        return ','.join(values)
+        return ', '.join(values)
 
     def _rewrite_css(self, css_content):
         if css_content:

--- a/pywb/rewrite/html_rewriter.py
+++ b/pywb/rewrite/html_rewriter.py
@@ -234,11 +234,13 @@ class HTMLRewriterMixin(StreamingRewriter):
 
         return new_value
 
+    SRCSET_REGEX = re.compile('\s*(\S*\s+[\d\.]+[wx]),|(?:\s*,(?:\s+|(?=https?:)))')
+
     def _rewrite_srcset(self, value, mod=''):
         if not value:
             return ''
 
-        values = (url for url in re.split("\s*(\S*\s+[\d\.]+[wx]),|(?:\s*,(?:\s+|(?=https?:)))", value) if url)
+        values = (url.strip() for url in re.split(self.SRCSET_REGEX, value) if url)
         values = [self._rewrite_url(v.strip()) for v in values]
         return ', '.join(values)
 

--- a/pywb/rewrite/html_rewriter.py
+++ b/pywb/rewrite/html_rewriter.py
@@ -238,7 +238,7 @@ class HTMLRewriterMixin(StreamingRewriter):
         if not value:
             return ''
 
-        values = (url for url in re.split("\s*(\S*\s+[\d\.]+[wx]),|(?:\s*,\s+)", value) if url)
+        values = (url for url in re.split("\s*(\S*\s+[\d\.]+[wx]),|(?:\s*,(?:\s+|(?=https?:)))", value) if url)
         values = [self._rewrite_url(v.strip()) for v in values]
         return ', '.join(values)
 

--- a/pywb/rewrite/html_rewriter.py
+++ b/pywb/rewrite/html_rewriter.py
@@ -238,8 +238,8 @@ class HTMLRewriterMixin(StreamingRewriter):
         if not value:
             return ''
 
-        values = (url.strip() for url in re.split("\s*(\S*\s+[\d\.]+[wx]),|(?:\s*,\s+)", value) if url)
-        values = [self._rewrite_url(v) for v in values]
+        values = (url for url in re.split("\s*(\S*\s+[\d\.]+[wx]),|(?:\s*,\s+)", value) if url)
+        values = [self._rewrite_url(v.strip()) for v in values]
         return ', '.join(values)
 
     def _rewrite_css(self, css_content):

--- a/pywb/rewrite/test/test_html_rewriter.py
+++ b/pywb/rewrite/test/test_html_rewriter.py
@@ -142,7 +142,7 @@ r"""
 
 # srcset attrib
 >>> parse('<img srcset="//example.com/1x 1x, //example.com/foo 2x, https://example.com/bar 4x">')
-<img srcset="/web/20131226101010///example.com/1x 1x,/web/20131226101010///example.com/foo 2x,/web/20131226101010/https://example.com/bar 4x">
+<img srcset="/web/20131226101010///example.com/1x 1x, /web/20131226101010///example.com/foo 2x, /web/20131226101010/https://example.com/bar 4x">
 
 # empty srcset attrib
 >>> parse('<img srcset="">')

--- a/pywb/rewrite/test/test_html_rewriter.py
+++ b/pywb/rewrite/test/test_html_rewriter.py
@@ -140,9 +140,41 @@ r"""
 >>> parse('<param value="foo bar"/>')
 <param value="foo bar"/>
 
-# srcset attrib
->>> parse('<img srcset="//example.com/1x 1x, //example.com/foo 2x, https://example.com/bar 4x">')
-<img srcset="/web/20131226101010///example.com/1x 1x, /web/20131226101010///example.com/foo 2x, /web/20131226101010/https://example.com/bar 4x">
+# srcset attrib: simple
+>>> parse('<img srcset="http://example.com">')
+<img srcset="/web/20131226101010/http://example.com">
+
+# srcset attrib: single comma-containing
+>>> parse('<img srcset="http://example.com/123,foo">')
+<img srcset="/web/20131226101010/http://example.com/123,foo">
+
+# srcset attrib: single comma-containing plus descriptor
+>>> parse('<img srcset="http://example.com/123,foo 2w">')
+<img srcset="/web/20131226101010/http://example.com/123,foo 2w">
+
+# srcset attrib: comma-containing absolute url and relative url, separated by comma and space
+#>>> parse('<img srcset="http://example.com/123,foo, /bar,bar 2w">')
+#<img srcset="/web/20131226101010/http://example.com/123,foo, /web/20131226101010/bar,bar 2w">
+
+# srcset attrib: comma-containing relative url and absolute url, separated by comma and space
+#>>> parse('<img srcset="/bar,bar 2w, http://example.com/123,foo">')
+#<img srcset="/web/20131226101010/bar,bar 2w, /web/20131226101010/http://example.com/123,foo">
+
+# srcset attrib: absolute urls with descriptors, separated by comma (no space)
+>>> parse('<img srcset="http://example.com/123 2w,http://example.com/ 4w">')
+<img srcset="/web/20131226101010/http://example.com/123 2w, /web/20131226101010/http://example.com/ 4w">
+
+# srcset attrib: absolute url with descriptor, separated by comma (no space) from absolute url without descriptor
+# >>> parse('<img srcset="http://example.com/123 2x,http://example.com/">')
+# <img srcset="/web/20131226101010/http://example.com/123 2x, /web/20131226101010/http://example.com/">
+
+# TODO: try to handle absolute url without descriptor, separated by comma (no space) from absolute url with descriptor
+# >>> parse('<img srcset="http://example.com/123,http://example.com/ 2x">')
+# <img srcset="/web/20131226101010/http://example.com/123, /web/20131226101010/http://example.com/ 2x">
+
+# complex srcset attrib
+>>> parse('<img srcset="//example.com/1x,1x 2w, //example1.com/foo 2x, http://example.com/bar,bar 4x">')
+<img srcset="/web/20131226101010///example.com/1x,1x 2w, /web/20131226101010///example1.com/foo 2x, /web/20131226101010/http://example.com/bar,bar 4x">
 
 # empty srcset attrib
 >>> parse('<img srcset="">')

--- a/pywb/rewrite/test/test_html_rewriter.py
+++ b/pywb/rewrite/test/test_html_rewriter.py
@@ -153,20 +153,20 @@ r"""
 <img srcset="/web/20131226101010/http://example.com/123,foo 2w">
 
 # srcset attrib: comma-containing absolute url and relative url, separated by comma and space
-#>>> parse('<img srcset="http://example.com/123,foo, /bar,bar 2w">')
-#<img srcset="/web/20131226101010/http://example.com/123,foo, /web/20131226101010/bar,bar 2w">
+>>> parse('<img srcset="http://example.com/123,foo, /bar,bar 2w">')
+<img srcset="/web/20131226101010/http://example.com/123,foo, /web/20131226101010/http://example.com/bar,bar 2w">
 
 # srcset attrib: comma-containing relative url and absolute url, separated by comma and space
-#>>> parse('<img srcset="/bar,bar 2w, http://example.com/123,foo">')
-#<img srcset="/web/20131226101010/bar,bar 2w, /web/20131226101010/http://example.com/123,foo">
+>>> parse('<img srcset="/bar,bar 2w, http://example.com/123,foo">')
+<img srcset="/web/20131226101010/http://example.com/bar,bar 2w, /web/20131226101010/http://example.com/123,foo">
 
 # srcset attrib: absolute urls with descriptors, separated by comma (no space)
 >>> parse('<img srcset="http://example.com/123 2w,http://example.com/ 4w">')
 <img srcset="/web/20131226101010/http://example.com/123 2w, /web/20131226101010/http://example.com/ 4w">
 
 # srcset attrib: absolute url with descriptor, separated by comma (no space) from absolute url without descriptor
-# >>> parse('<img srcset="http://example.com/123 2x,http://example.com/">')
-# <img srcset="/web/20131226101010/http://example.com/123 2x, /web/20131226101010/http://example.com/">
+>>> parse('<img srcset="http://example.com/123 2x,http://example.com/">')
+<img srcset="/web/20131226101010/http://example.com/123 2x, /web/20131226101010/http://example.com/">
 
 # TODO: try to handle absolute url without descriptor, separated by comma (no space) from absolute url with descriptor
 # >>> parse('<img srcset="http://example.com/123,http://example.com/ 2x">')

--- a/pywb/rewrite/test/test_html_rewriter.py
+++ b/pywb/rewrite/test/test_html_rewriter.py
@@ -168,9 +168,9 @@ r"""
 >>> parse('<img srcset="http://example.com/123 2x,http://example.com/">')
 <img srcset="/web/20131226101010/http://example.com/123 2x, /web/20131226101010/http://example.com/">
 
-# TODO: try to handle absolute url without descriptor, separated by comma (no space) from absolute url with descriptor
-# >>> parse('<img srcset="http://example.com/123,http://example.com/ 2x">')
-# <img srcset="/web/20131226101010/http://example.com/123, /web/20131226101010/http://example.com/ 2x">
+# srcset attrib: absolute url without descriptor, separated by comma (no space) from absolute url with descriptor
+>>> parse('<img srcset="http://example.com/123,http://example.com/ 2x">')
+<img srcset="/web/20131226101010/http://example.com/123, /web/20131226101010/http://example.com/ 2x">
 
 # complex srcset attrib
 >>> parse('<img srcset="//example.com/1x,1x 2w, //example1.com/foo 2x, http://example.com/bar,bar 4x">')

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -1374,7 +1374,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
         }
 
         // Filter removes non-truthy values like null, undefined, and ""
-        values = value.split(/\s*(\S*\s+[\d\.]+[wx]),|(?:\s*,\s+)/).filter(Boolean);
+        values = value.split(/\s*(\S*\s+[\d\.]+[wx]),|(?:\s*,(?:\s+|(?=https?:)))/).filter(Boolean);
 
         for (var i = 0; i < values.length; i++) {
             values[i] = rewrite_url(values[i].trim());

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -1373,7 +1373,8 @@ var _WBWombat = function($wbwindow, wbinfo) {
             return "";
         }
 
-        values = value.split(',');
+        // Filter removes non-truthy values like null, undefined, and ""
+        values = value.split(/\s*(\S*\s+[\d\.]+[wx]),|(?:\s*,\s+)/).filter(Boolean);
 
         for (var i = 0; i < values.length; i++) {
             values[i] = rewrite_url(values[i].trim());

--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -1379,7 +1379,7 @@ var _WBWombat = function($wbwindow, wbinfo) {
             values[i] = rewrite_url(values[i].trim());
         }
 
-        return values.join(",");
+        return values.join(", ");
     }
 
     //============================================


### PR DESCRIPTION
Part 1: This PR offers a tiny tweak, the result of investigating why certain images at https://lil.law.harvard.edu, like the logo, aren't currently being captured/played back.

It turns out that websites using `srcset` to implement responsive images normally define a list of sources separated by [both commas and whitespace](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images). The whitespace is necessary since URLs can contain commas in the path section without being percent-encoded (see related issue https://github.com/ikreymer/pywb/issues/238). Without the whitespace, browsers will/may interpret the list of sources as one giant url. 

The LIL src html:
```
<img src="/assets/images/header-splash-logo-ani@1x.gif" srcset="/assets/images/header-splash-logo-ani@1x.gif, /assets/images/header-splash-logo-ani@2x.gif 2x" alt="Library Innovation Lab" class="img-full-width">
```

currently results in the rewritten html:
```
<img src="/live/im_/https://lil.law.harvard.edu/assets/images/header-splash-logo-ani@1x.gif" srcset="/live/mp_/https://lil.law.harvard.edu/assets/images/header-splash-logo-ani@1x.gif,/live/mp_/https://lil.law.harvard.edu/assets/images/header-splash-logo-ani@2x.gif 2x" alt="Library Innovation Lab" class="img-full-width">
```

which results in the request (404 Not Found):
```
::1 - - [2017-12-18 11:12:18] "GET /live/mp_/https://lil.law.harvard.edu/assets/images/header-splash-logo-ani@1x.gif,/live/mp_/https://lil.law.harvard.edu/assets/images/header-splash-logo-ani@2x.gif HTTP/1.1" 404 6790 0.137927
```

By joining with ", " instead of "," these images are captured and played back as expected.