### PR TITLE
Disable meta tag delivered Content-Security-Policies

### DIFF
--- a/pywb/rewrite/html_rewriter.py
+++ b/pywb/rewrite/html_rewriter.py
@@ -333,6 +333,8 @@ class HTMLRewriterMixin(StreamingRewriter):
             elif (tag == 'meta') and (attr_name == 'content'):
                 if self.has_attr(tag_attrs, ('http-equiv', 'refresh')):
                     attr_value = self._rewrite_meta_refresh(attr_value)
+                elif self.has_attr(tag_attrs, ('http-equiv', 'content-security-policy')):
+                    attr_name = '_' + attr_name
                 elif self.has_attr(tag_attrs, ('name', 'referrer')):
                     attr_value = 'no-referrer-when-downgrade'
                 elif attr_value.startswith(self.DATA_RW_PROTOCOLS):

--- a/pywb/rewrite/test/test_html_rewriter.py
+++ b/pywb/rewrite/test/test_html_rewriter.py
@@ -129,6 +129,9 @@ r"""
 >>> parse('<meta name="referrer" content="origin">')
 <meta name="referrer" content="no-referrer-when-downgrade">
 
+>>> parse('<meta http-equiv="Content-Security-Policy" content="default-src http://example.com" />')
+<meta http-equiv="Content-Security-Policy" _content="default-src http://example.com"/>
+
 # Custom -data attribs
 >>> parse('<div data-url="http://example.com/a/b/c.html" data-some-other-value="http://example.com/img.gif">')
 <div data-url="/web/20131226101010oe_/http://example.com/a/b/c.html" data-some-other-value="/web/20131226101010oe_/http://example.com/img.gif">


### PR DESCRIPTION
This PR provides the rewriting of meta tag delivered Content-Security-Policies.
The rewriting of the tag is handled like the integrity attribute.

Fixes #273 
  