### PR TITLE
Improve wombats fetch override

### DIFF
--- a/pywb/static/wombat.js
+++ b/pywb/static/wombat.js
@@ -907,13 +907,17 @@ var _WBWombat = function($wbwindow, wbinfo) {
         var orig_fetch = $wbwindow.fetch;
 
         $wbwindow.fetch = function(input, init_opts) {
-            if (typeof(input) === "string") {
+            var inputType = typeof(input);
+            if (inputType === "string") {
                 input = rewrite_url(input);
-            } else if (typeof(input) === "object" && input.url) {
+            } else if (inputType === "object" && input.url) {
                 var new_url = rewrite_url(input.url);
                 if (new_url != input.url) {
                     input = new Request(new_url, input);
                 }
+            } else if (inputType === "object" && input.href) {
+                // it is likely that input is either window.location or window.URL
+                input = rewrite_url(input.href);
             }
 
             init_opts = init_opts || {};


### PR DESCRIPTION
This PR improves wombats fetch override and fixes #275. 
Both WombatLocation and URL have the property href whose getter results in an unrewritten URL, likewise when these objects are coerced to a string or the toString method is called.
This is undesired behavior when using Pywb or Webrecorder.
The fix is simple, added an additional check if input is of type object and has an href property which is non-null.
If so rewrite input.href and reassign input to the rewritten URL.  
